### PR TITLE
Add foreldrepengesoknad URLs to CorsInterceptor

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/felles/filters/CorsInterceptor.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/felles/filters/CorsInterceptor.java
@@ -21,8 +21,13 @@ public class CorsInterceptor extends HandlerInterceptorAdapter {
     private final List<String> allowedOrigins;
 
     @Inject
-    public CorsInterceptor(
-            @Value("${no.nav.foreldrepenger.api.allowed.origins:http://localhost:8080,https://engangsstonad.nais.oera-q.local,https://engangsstonad-q.nav.no,https://engangsstonad.nav.no}") String... allowedOrigins) {
+    public CorsInterceptor(@Value("${no.nav.foreldrepenger.api.allowed.origins:" +
+            "https://engangsstonad.nais.oera-q.local," +
+            "https://engangsstonad-q.nav.no," +
+            "https://engangsstonad.nav.no," +
+            "https://foreldrepengesoknad.nais.oera-q.local, " +
+            "https://foreldrepengesoknad-q.nav.no," +
+            "https://foreldrepengesoknad.nav.no}") String... allowedOrigins) {
         this(Arrays.asList(allowedOrigins));
     }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -7,6 +7,8 @@ server.servlet.context-path=/foreldrepengesoknad-api
 spring.servlet.multipart.max-file-size=5MB
 spring.profiles.active=dev
 
+no.nav.foreldrepenger.api.allowed.origins=http://localhost:8080
+
 server.port=8888
 FPSOKNAD_OPPSLAG_API_URL=http://localhost:9000/api
 FPSOKNAD_MOTTAK_API_URL=http://localhost:9001/api
@@ -22,3 +24,4 @@ stub.oppslag=true
 stub.mottak=true
 
 http.proxy=
+


### PR DESCRIPTION
Cors for localhost URL is not needed in prod and is therefore moved to application.properties used by dev profile.