### PR TITLE
bump oidc-spring-support to 0.2.11 and enable filter for token expiration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <springfox.version>2.8.0</springfox.version>
-        <oidc-spring-support.version>0.2.3</oidc-spring-support.version>
+        <oidc-spring-support.version>0.2.11</oidc-spring-support.version>
     </properties>
     <dependencies>
         <dependency>
@@ -140,9 +140,15 @@
         </dependency>
         <dependency>
             <groupId>no.nav.security</groupId>
-            <artifactId>oidc-spring-test</artifactId>
+            <artifactId>oidc-test-support</artifactId>
             <version>${oidc-spring-support.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-jersey</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/ApiApplication.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/ApiApplication.java
@@ -1,14 +1,13 @@
 package no.nav.foreldrepenger.selvbetjening;
 
+import no.nav.security.spring.oidc.api.EnableOIDCTokenValidation;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 
 import io.prometheus.client.hotspot.DefaultExports;
-import no.nav.security.spring.oidc.validation.api.EnableOIDCTokenValidation;
 
 @SpringBootApplication
-@ComponentScan
 @EnableOIDCTokenValidation(ignore = { "org.springframework", "springfox.documentation" })
 public class ApiApplication {
 

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/felles/storage/StorageController.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/felles/storage/StorageController.java
@@ -1,8 +1,8 @@
 package no.nav.foreldrepenger.selvbetjening.felles.storage;
 
 import no.nav.foreldrepenger.selvbetjening.felles.util.FnrExtractor;
+import no.nav.security.oidc.api.ProtectedWithClaims;
 import no.nav.security.oidc.context.OIDCRequestContextHolder;
-import no.nav.security.spring.oidc.validation.api.ProtectedWithClaims;
 import org.slf4j.Logger;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/InnsendingController.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/InnsendingController.java
@@ -9,6 +9,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import no.nav.foreldrepenger.selvbetjening.innsending.json.Ettersending;
+import no.nav.security.oidc.api.ProtectedWithClaims;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +28,7 @@ import no.nav.foreldrepenger.selvbetjening.innsending.json.Søknad;
 import no.nav.foreldrepenger.selvbetjening.innsending.json.Vedlegg;
 import no.nav.foreldrepenger.selvbetjening.innsending.tjeneste.Innsending;
 import no.nav.security.oidc.context.OIDCRequestContextHolder;
-import no.nav.security.spring.oidc.validation.api.ProtectedWithClaims;
+
 
 @RestController
 @ProtectedWithClaims(issuer = "selvbetjening", claimMap = { "acr=Level4" })

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/oppslag/OppslagController.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/oppslag/OppslagController.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import no.nav.security.oidc.api.ProtectedWithClaims;
 import org.slf4j.Logger;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,7 +18,6 @@ import no.nav.foreldrepenger.selvbetjening.oppslag.json.Søkerinfo;
 import no.nav.foreldrepenger.selvbetjening.oppslag.tjeneste.Oppslag;
 import no.nav.foreldrepenger.selvbetjening.oppslag.tjeneste.json.PersonDto;
 import no.nav.foreldrepenger.selvbetjening.oppslag.tjeneste.json.SøkerinfoDto;
-import no.nav.security.spring.oidc.validation.api.ProtectedWithClaims;
 
 @RestController
 @ProtectedWithClaims(issuer = "selvbetjening", claimMap = { "acr=Level4" })

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,11 @@ spring :
   metrics.web.server.auto-time-requests: true
   servlet.multipart.max-file-size: 9MB
 no.nav.security.oidc:
+  # will send a x-token-expires-soon response header when a tokens remaining lifetime is
+  # less than or equal to this value (in minutes). set to 35 min to allow to refresh idporten login without entering credentials
+  # idporten session timeout is 30 min while azure ad b2c operates with 60 min lifetime, 35min will allow for 5 min reamining
+  # until token expires.
+  expirythreshold: 35
   issuers: selvbetjening
   issuer.selvbetjening:
     discoveryurl: <Set from Fasit>

--- a/src/test/java/no/nav/foreldrepenger/selvbetjening/ApplicationLocal.java
+++ b/src/test/java/no/nav/foreldrepenger/selvbetjening/ApplicationLocal.java
@@ -2,6 +2,8 @@ package no.nav.foreldrepenger.selvbetjening;
 
 import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
 
+import no.nav.security.oidc.test.support.spring.TokenGeneratorConfiguration;
+import no.nav.security.spring.oidc.api.EnableOIDCTokenValidation;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
@@ -10,8 +12,7 @@ import org.springframework.context.annotation.Import;
 
 import io.prometheus.client.hotspot.DefaultExports;
 import no.nav.foreldrepenger.selvbetjening.felles.util.EnvUtil;
-import no.nav.security.spring.oidc.test.TokenGeneratorConfiguration;
-import no.nav.security.spring.oidc.validation.api.EnableOIDCTokenValidation;
+
 
 @SpringBootApplication
 @EnableOIDCTokenValidation(ignore = { "org.springframework", "springfox.documentation" })

--- a/src/test/java/no/nav/foreldrepenger/selvbetjening/felles/storage/AttachmentTestHttpHandler.java
+++ b/src/test/java/no/nav/foreldrepenger/selvbetjening/felles/storage/AttachmentTestHttpHandler.java
@@ -1,6 +1,6 @@
 package no.nav.foreldrepenger.selvbetjening.felles.storage;
 
-import no.nav.security.spring.oidc.test.JwtTokenGenerator;
+import no.nav.security.oidc.test.support.JwtTokenGenerator;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.*;

--- a/src/test/java/no/nav/foreldrepenger/selvbetjening/felles/storage/SoknadStorageHttpTest.java
+++ b/src/test/java/no/nav/foreldrepenger/selvbetjening/felles/storage/SoknadStorageHttpTest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import no.nav.foreldrepenger.selvbetjening.ApplicationLocal;
 import no.nav.foreldrepenger.selvbetjening.SlowTests;
 import no.nav.foreldrepenger.selvbetjening.stub.StubbedLocalStackContainer;
-import no.nav.security.spring.oidc.test.JwtTokenGenerator;
+import no.nav.security.oidc.test.support.JwtTokenGenerator;
 import org.junit.*;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;

--- a/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/tjeneste/InnsendingHttpTest.java
+++ b/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/tjeneste/InnsendingHttpTest.java
@@ -9,7 +9,7 @@ import no.nav.foreldrepenger.selvbetjening.felles.storage.AttachmentTestHttpHand
 import no.nav.foreldrepenger.selvbetjening.innsending.json.Barn;
 import no.nav.foreldrepenger.selvbetjening.innsending.json.Engangsstønad;
 import no.nav.foreldrepenger.selvbetjening.innsending.json.Vedlegg;
-import no.nav.security.spring.oidc.test.JwtTokenGenerator;
+import no.nav.security.oidc.test.support.JwtTokenGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -26,3 +26,5 @@ stub.mottak=true
 http.proxy=
 
 TOGGLES_ENABLE_FORELDREPENGESOKNAD=true
+
+logging.level.no.nav: DEBUG


### PR DESCRIPTION
* refactoring due to api changes
* new property for expiration threshold, i.e. when to return a response header stating token needs refreshing