### PR TITLE
nyIArbeidslivet-fix

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/json/arbeid/SelvstendigNæringsdrivendeInformasjon.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/json/arbeid/SelvstendigNæringsdrivendeInformasjon.java
@@ -13,7 +13,7 @@ public class SelvstendigNæringsdrivendeInformasjon {
     public Boolean registrertINorge;
     public String registrertILand;
     public Double stillingsprosent;
-    public Boolean nyIArbeidslivet;
+    public Boolean harBlittYrkesaktivILøpetAvDeTreSisteFerdigliknedeÅrene;
     public TilknyttetPerson regnskapsfører;
     public TilknyttetPerson revisor;
     public Boolean hattVarigEndringAvNæringsinntektSiste4Kalenderår;

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/tjeneste/json/OpptjeningDto.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/tjeneste/json/OpptjeningDto.java
@@ -126,6 +126,8 @@ public class OpptjeningDto {
             TilknyttetPerson regnskapsfører = selvstendig.regnskapsfører;
             TilknyttetPerson revisor = selvstendig.revisor;
 
+            LocalDate fireÅrSiden = LocalDate.now().minus(Period.ofYears(4)).minus(Period.ofDays(1));
+
             this.type = selvstendig.registrertINorge ? "norsk" : "utenlandsk";
             this.stillingsprosent = selvstendig.stillingsprosent;
             this.orgNummer = selvstendig.registrertINorge ? selvstendig.organisasjonsnummer : null;
@@ -133,7 +135,8 @@ public class OpptjeningDto {
             this.periode.fom = selvstendig.tidsperiode.fom;
             this.periode.tom = selvstendig.tidsperiode.tom;
             this.arbeidsland = selvstendig.registrertILand;
-            this.erNyIArbeidslivet = selvstendig.nyIArbeidslivet;
+            this.erNyOpprettet = selvstendig.harBlittYrkesaktivILøpetAvDeTreSisteFerdigliknedeÅrene;
+            this.erNyIArbeidslivet = this.periode.fom.isAfter(fireÅrSiden);
             this.erVarigEndring = selvstendig.hattVarigEndringAvNæringsinntektSiste4Kalenderår;
             this.vedlegg = selvstendig.vedlegg;
 

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/tjeneste/json/OpptjeningDto.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/tjeneste/json/OpptjeningDto.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.tjeneste.json;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+import static java.time.LocalDate.now;
 
 import java.time.LocalDate;
 import java.time.Period;
@@ -65,7 +66,7 @@ public class OpptjeningDto {
             this.periode.fom = frilansInformasjon.oppstart;
             this.harInntektFraFosterhjem = frilansInformasjon.driverFosterhjem;
 
-            LocalDate treMånederFørFom = LocalDate.now().minus(Period.ofDays(90));
+            LocalDate treMånederFørFom = now().minus(Period.ofDays(90));
             this.nyOppstartet = this.periode.fom.isAfter(treMånederFørFom);
 
             for (Frilansoppdrag o : frilansInformasjon.oppdragForNæreVennerEllerFamilieSiste10Mnd) {
@@ -126,7 +127,7 @@ public class OpptjeningDto {
             TilknyttetPerson regnskapsfører = selvstendig.regnskapsfører;
             TilknyttetPerson revisor = selvstendig.revisor;
 
-            LocalDate fireÅrSiden = LocalDate.now().minus(Period.ofYears(4)).minus(Period.ofDays(1));
+            LocalDate fireÅrSiden = now().minusYears(4);
 
             this.type = selvstendig.registrertINorge ? "norsk" : "utenlandsk";
             this.stillingsprosent = selvstendig.stillingsprosent;
@@ -136,7 +137,7 @@ public class OpptjeningDto {
             this.periode.tom = selvstendig.tidsperiode.tom;
             this.arbeidsland = selvstendig.registrertILand;
             this.erNyOpprettet = selvstendig.harBlittYrkesaktivILøpetAvDeTreSisteFerdigliknedeÅrene;
-            this.erNyIArbeidslivet = this.periode.fom.isAfter(fireÅrSiden);
+            this.erNyIArbeidslivet = this.periode.fom.isAfter(fireÅrSiden.minusDays(1));
             this.erVarigEndring = selvstendig.hattVarigEndringAvNæringsinntektSiste4Kalenderår;
             this.vedlegg = selvstendig.vedlegg;
 


### PR DESCRIPTION
Make sure erNyOpprettet is set to value of harBlittYrkesaktivILøpetAvDeTreSisteFerdigliknedeÅrene sent
from client.
Always set erNyIArbeidslivet automatically based on whether its more or equal/less than 4 years
ago since SelvstendigNæringsdrivendeInformasjon.tidsperiode.fom-Date.