### PR TITLE
Legger til støtte for å veksle inn TokenX i dev og send inn til mottak.

### DIFF
--- a/.deploy/dev-gcp-teamforeldrepenger.json
+++ b/.deploy/dev-gcp-teamforeldrepenger.json
@@ -3,7 +3,7 @@
   "fpbucket": "foreldrepengesoknad",
   "tmpbucket": "mellomlagring",
   "ingresses": ["https://foreldrepengesoknad-api.dev.nav.no","https://foreldrepengesoknad-api.dev.intern.nav.no"],
-  "gw" : "api-gw-q1.oera.no",
-  "gcp" : "true"
+  "gcp" : "true",
+  "tokenx" : "true",
+  "tokenxurl": ["fpsoknad-mottak.dev-fss-pub.nais.io", "fpinfo-historikk.dev-fss-pub.nais.io"]
 }
-

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   envFrom:
      - configmap: loginservice-idporten
+{{#if tokenx}}
+  tokenx:
+    enabled: true
+{{/if}}
 {{#if gcp}}
      - secret: apigw
   gcp:
@@ -24,6 +28,9 @@ spec:
          - host: oauth2.googleapis.com
          - host: www.googleapis.com
          - host: {{gw}}
+{{#each tokenxurl as |url|}}
+         - host: {{url}}
+{{/each}}
 {{/if}}
   image: {{image}}
   port: 8080

--- a/.deploy/prod-gcp-teamforeldrepenger.json
+++ b/.deploy/prod-gcp-teamforeldrepenger.json
@@ -4,5 +4,6 @@
   "tmpbucket": "mellomlagring-prod",
   "ingresses": ["https://foreldrepengesoknad-api.intern.nav.no","https://foreldrepengesoknad-api.nav.no"],
   "gw" : "api-gw.oera.no",
-  "gcp" : "true"
+  "gcp" : "true",
+  "tokenx" : "false"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,11 @@
 			<artifactId>token-validation-spring</artifactId>
 			<version>${token-validation-version}</version>
 		</dependency>
+        <dependency>
+            <groupId>no.nav.security</groupId>
+            <artifactId>token-client-spring</artifactId>
+            <version>${token-validation-version}</version>
+        </dependency>
 		<dependency>
 			<groupId>no.nav.security</groupId>
 			<artifactId>token-validation-spring-test</artifactId>

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/ApiApplication.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/ApiApplication.java
@@ -8,6 +8,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.retry.annotation.EnableRetry;
 
+import no.nav.security.token.support.client.spring.oauth2.EnableOAuth2Client;
 import no.nav.security.token.support.spring.api.EnableJwtTokenValidation;
 import springfox.documentation.oas.annotations.EnableOpenApi;
 
@@ -15,6 +16,7 @@ import springfox.documentation.oas.annotations.EnableOpenApi;
 @EnableOpenApi
 @EnableCaching
 @EnableRetry
+@EnableOAuth2Client(cacheEnabled = true)
 @ConfigurationPropertiesScan("no.nav.foreldrepenger.selvbetjening")
 @EnableJwtTokenValidation(ignore = { "org.springframework", "springfox.documentation" })
 public class ApiApplication {

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/http/interceptors/TokenExchangeClientRequestInterceptor.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/http/interceptors/TokenExchangeClientRequestInterceptor.java
@@ -1,0 +1,52 @@
+package no.nav.foreldrepenger.selvbetjening.http.interceptors;
+
+import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+
+import no.nav.foreldrepenger.boot.conditionals.ConditionalOnDev;
+import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService;
+import no.nav.security.token.support.client.spring.ClientConfigurationProperties;
+
+@ConditionalOnDev
+@Component
+@Order(HIGHEST_PRECEDENCE)
+public class TokenExchangeClientRequestInterceptor implements ClientHttpRequestInterceptor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TokenExchangeClientRequestInterceptor.class);
+    private final ClientConfigurationProperties configs;
+    private final OAuth2AccessTokenService service;
+    private final TokenXConfigFinder finder;
+
+    public TokenExchangeClientRequestInterceptor(ClientConfigurationProperties configs,
+                                                 OAuth2AccessTokenService service, TokenXConfigFinder finder) {
+        this.configs = configs;
+        this.service = service;
+        this.finder = finder;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest req, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+        LOG.trace("Intercepting {}", req.getURI());
+        Optional.ofNullable(finder.findProperties(configs, req.getURI()))
+                .ifPresentOrElse(config -> req.getHeaders().setBearerAuth(service.getAccessToken(config).getAccessToken()),
+                        () -> LOG.info("Ingen konfig for {}", req.getURI()));
+        return execution.execute(req, body);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [configs=" + configs + ", service=" + service + ", finder=" + finder + "]";
+    }
+
+}

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/http/interceptors/TokenXConfigFinder.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/http/interceptors/TokenXConfigFinder.java
@@ -1,0 +1,10 @@
+package no.nav.foreldrepenger.selvbetjening.http.interceptors;
+
+import java.net.URI;
+
+import no.nav.security.token.support.client.core.ClientProperties;
+import no.nav.security.token.support.client.spring.ClientConfigurationProperties;
+
+public interface TokenXConfigFinder {
+    ClientProperties findProperties(ClientConfigurationProperties configs, URI uri);
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,15 +11,35 @@ spring:
     mvc:
         log-request-details: true
 
+no.nav:
+    security:
+        jwt:
+            client:
+                registration:
+                    fpsoknad-mottak:
+                        well-known-url: ${token.x.well.known.url}
+                        grant-type: urn:ietf:params:oauth:grant-type:token-exchange
+                        authentication:
+                            client-id: ${token.x.client.id}
+                            client-jwk: ${token.x.private.jwk}
+                            client-auth-method: private_key_jwt
+                    fpinfo-historikk:
+                        well-known-url: ${token.x.well.known.url}
+                        grant-type: urn:ietf:params:oauth:grant-type:token-exchange
+                        authentication:
+                            client-id: ${token.x.client.id}
+                            client-jwk: ${token.x.private.jwk}
+                            client-auth-method: private_key_jwt
+
 oppslag:
-  uri:  https://api-gw-q1.oera.no/fpsoknad-mottak/api/
+  uri:  https://fpsoknad-mottak.dev-fss-pub.nais.io/api/
 historikk:
-  uri: https://api-gw-q1.oera.no/fpinfo-historikk/api/
+  uri: https://fpinfo-historikk.dev-fss-pub.nais.io/api/
 mottak:
-  uri: https://api-gw-q1.oera.no/fpsoknad-mottak/api/
+  uri: https://fpsoknad-mottak.dev-fss-pub.nais.io/api/
 innsyn:
-  uri: https://api-gw-q1.oera.no/fpsoknad-mottak/api/
+  uri: https://fpsoknad-mottak.dev-fss-pub.nais.io/api/
 minidialog:
-  uri: https://api-gw-q1.oera.no/fpinfo-historikk/api/
+  uri: https://fpsoknad-mottak.dev-fss-pub.nais.io/api/
 fppdfgen:
-  uri: https://api-gw-q1.oera.no/fppdfgen/
+  uri: http://fppdfgen


### PR DESCRIPTION
Tenker vi utforsker litt i dev først. Nå aktiverer vi en interceptor i dev som veksler til seg TOKENX token ved kall mot fpsoknad-mottak eller fpinfo-historikk.

I prod skal det i teorien ikke være noe endring, men burde kanskje undersøke om det har noen sideeffekter – som vi ikke forutså – av å legge til annoteringen i main klasse (@EnableOAuth2Client(cacheEnabled = true)).

Videre så må vi legge til logikk slik at mottak kan håndtere både TokenX token og Loginservice token (grace periode) til API bare sender TokenX.
PR -> https://github.com/navikt/fpsoknad-mottak/pull/1608