### PR TITLE
Log path

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/http/filters/HeadersToMDCFilterBean.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/http/filters/HeadersToMDCFilterBean.java
@@ -4,7 +4,6 @@ import static no.nav.foreldrepenger.common.util.Constants.NAV_AUTH_LEVEL;
 import static no.nav.foreldrepenger.common.util.Constants.NAV_CALL_ID;
 import static no.nav.foreldrepenger.common.util.Constants.NAV_CONSUMER_ID;
 import static no.nav.foreldrepenger.common.util.Constants.NAV_USER_ID;
-import static no.nav.foreldrepenger.common.util.MDCUtil.callId;
 import static no.nav.foreldrepenger.common.util.MDCUtil.toMDC;
 
 import java.io.IOException;
@@ -49,7 +48,6 @@ public class HeadersToMDCFilterBean extends GenericFilterBean {
         var uri = ((HttpServletRequest) req).getRequestURI();
         putValues((HttpServletRequest) req, uri);
         chain.doFilter(req, response);
-
     }
 
     private void putValues(HttpServletRequest request, String uri) {
@@ -59,7 +57,7 @@ public class HeadersToMDCFilterBean extends GenericFilterBean {
             toMDC(NAV_AUTH_LEVEL, Optional.ofNullable(tokenUtil.getLevel()).map(AuthenticationLevel::name).orElse(AuthenticationLevel.NONE.name()));
             toMDC(NAV_CALL_ID, request.getHeader(NAV_CALL_ID), generator.create());
             if (tokenUtil.erAutentisert()) {
-                SECURE_LOGGER.info("Bruker med fødselsnummer {} er koblet til følgende Nav-CallId {}", tokenUtil.getSubject(), callId());
+                SECURE_LOGGER.info("FNR {} - {} {}", tokenUtil.getSubject(), request.getMethod(), request.getRequestURI());
             }
         } catch (Exception e) {
             LOG.warn("Noe gikk galt ved setting av MDC-verdier for request {}, MDC-verdier er inkomplette", uri, e);

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/http/filters/HeadersToMDCFilterBean.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/http/filters/HeadersToMDCFilterBean.java
@@ -56,6 +56,7 @@ public class HeadersToMDCFilterBean extends GenericFilterBean {
             toMDC(NAV_USER_ID, Optional.ofNullable(tokenUtil.getSubject()).map(StringUtil::partialMask).orElse("Uautentisert"));
             toMDC(NAV_AUTH_LEVEL, Optional.ofNullable(tokenUtil.getLevel()).map(AuthenticationLevel::name).orElse(AuthenticationLevel.NONE.name()));
             toMDC(NAV_CALL_ID, request.getHeader(NAV_CALL_ID), generator.create());
+            toMDC("JTI", tokenUtil.getJti());
             if (tokenUtil.erAutentisert()) {
                 SECURE_LOGGER.info("FNR {} - {} {}", tokenUtil.getSubject(), request.getMethod(), request.getRequestURI());
             }

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/util/TokenUtil.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/util/TokenUtil.java
@@ -66,6 +66,12 @@ public class TokenUtil {
                 .orElseThrow(() -> new JwtTokenValidatorException("Fant ikke subject", getExpiryDate(), null));
     }
 
+    public String getJti() {
+        return Optional.ofNullable(claimSet())
+            .map(c -> c.getStringClaim("jti"))
+            .orElse("");
+    }
+
     private JwtTokenClaims claimSet() {
         return Optional.ofNullable(context())
                 .map(s -> s.getClaims(ISSUER))

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -48,6 +48,7 @@
     <logger name="org.apache.pdfbox.pdfparser.XrefTrailerResolver" level="ERROR" />
     <logger name="org.apache.pdfbox.pdmodel.font" level="ERROR" />
     <logger name="org.apache.pdfbox.rendering.CIDType0Glyph2D" level="ERROR" />
+    <logger name="org.apache.pdfbox.pdfparser.COSParser" level="ERROR" />
     <root level="info">
         <appender-ref ref="stdout"/>
     </root>


### PR DESCRIPTION
Legger jti til mdc (loginservice logger også jti pt, så må anses som ok). Konstantene ligger i felles, så må utvide der senere om dette funker fint.

Endrer logging til securelog til å inneholde fnr + method + path (uten query params pt.. kan kanskje legge til om interessant). CallId ligger i mdc så sikkert greiere å bare pinne fra feltet i kibana - fjernet derfor fra message.