### PR TITLE
Legger til tjeneste som fjerner duplikate vedlegg fra søknad/ettersen…

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/InnsendingConnection.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/InnsendingConnection.java
@@ -1,14 +1,11 @@
 package no.nav.foreldrepenger.selvbetjening.innsending;
 
 import static java.time.LocalDateTime.now;
-import static no.nav.foreldrepenger.common.util.StreamUtil.safeStream;
-import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilVedlegg;
 import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.EttersendingMapper.tilEttersending;
 import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.SøknadMapper.tilSøknad;
 import static no.nav.foreldrepenger.selvbetjening.util.StringUtils.escapeHtml;
 
 import java.net.URI;
-import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,25 +14,21 @@ import org.springframework.web.client.RestOperations;
 
 import no.nav.foreldrepenger.common.domain.Kvittering;
 import no.nav.foreldrepenger.common.domain.Søknad;
-import no.nav.foreldrepenger.common.domain.felles.Vedlegg;
 import no.nav.foreldrepenger.selvbetjening.http.AbstractRestConnection;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.EttersendingFrontend;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.SøknadFrontend;
-import no.nav.foreldrepenger.selvbetjening.innsending.domain.VedleggFrontend;
-import no.nav.foreldrepenger.selvbetjening.vedlegg.Image2PDFConverter;
 
 @Component
 public class InnsendingConnection extends AbstractRestConnection {
-    private static final Logger LOG = LoggerFactory.getLogger(InnsendingConnection.class);
     private static final Logger SECURE_LOGGER = LoggerFactory.getLogger("secureLogger");
 
     private final InnsendingConfig config;
-    private final Image2PDFConverter converter;
+    private final VedleggsHåndteringTjeneste vedleggshåndtering;
 
-    public InnsendingConnection(RestOperations operations, InnsendingConfig config, Image2PDFConverter converter) {
+    public InnsendingConnection(RestOperations operations, InnsendingConfig config, VedleggsHåndteringTjeneste vedleggshåndtering) {
         super(operations);
         this.config = config;
-        this.converter = converter;
+        this.vedleggshåndtering = vedleggshåndtering;
     }
 
     public Kvittering sendInn(SøknadFrontend søknad) {
@@ -56,46 +49,16 @@ public class InnsendingConnection extends AbstractRestConnection {
     }
 
     public Søknad body(SøknadFrontend søknadFrontend) {
-        if (LOG.isInfoEnabled()) {
-            SECURE_LOGGER.info("{} mottatt fra frontend med følende innhold: {}", søknadFrontend.getType(), escapeHtml(søknadFrontend));
-        }
-        var dto = tilSøknad(søknadFrontend);
-
-        var unikeVedleggMedInnhold = hentUnikeVedleggMedInnhold(søknadFrontend.getVedlegg());
-        dto.getVedlegg().addAll(unikeVedleggMedInnhold);
-
-        if (søknadFrontend.getVedlegg().size() > unikeVedleggMedInnhold.size()) {
-            LOG.info("Mottatt duplikate vedlegg fra frontend ved innsending av søknad. Fjerner duplikate vedlegg. Sjekk secure logg for mer info.");
-        }
-        return dto;
+        SECURE_LOGGER.info("{} mottatt fra frontend med følende innhold: {}", søknadFrontend.getType(), escapeHtml(søknadFrontend));
+        søknadFrontend = vedleggshåndtering.fjernDupliserteVedlegg(søknadFrontend);
+        return tilSøknad(søknadFrontend);
     }
 
     public no.nav.foreldrepenger.common.domain.felles.Ettersending body(EttersendingFrontend ettersending) {
-        var dto = tilEttersending(ettersending);
-
-        var unikeVedleggMedInnhold = hentUnikeVedleggMedInnhold(ettersending.vedlegg());
-        dto.vedlegg().addAll(unikeVedleggMedInnhold);
-
-        if (ettersending.vedlegg().size() > unikeVedleggMedInnhold.size()) {
-            LOG.info("Mottatt duplikate vedlegg under ettersending. Fjerner duplikate vedlegg. Sjekk secure logg for mer info.");
-            if (LOG.isInfoEnabled()) {
-                SECURE_LOGGER.info("Ettersendte vedlegg fra frontend før vasking er {}", escapeHtml(ettersending.vedlegg()));
-            }
-        }
-        return dto;
+        ettersending = vedleggshåndtering.fjernDupliserteVedlegg(ettersending);
+        return tilEttersending(ettersending);
     }
 
-    private List<Vedlegg> hentUnikeVedleggMedInnhold(List<VedleggFrontend> vedleggFrontend) {
-        return safeStream(vedleggFrontend).distinct().map(v -> tilVedlegg(convert(v))).toList();
-    }
-
-    private VedleggFrontend convert(VedleggFrontend v) {
-        var vedlegg = v.kopi();
-        if ((v.getContent() != null) && (v.getContent().length > 0)) {
-            vedlegg.setContent(converter.convert(v.getContent()));
-        }
-        return vedlegg;
-    }
 
     @Override
     public String toString() {

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/InnsendingTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/InnsendingTjeneste.java
@@ -1,23 +1,22 @@
 package no.nav.foreldrepenger.selvbetjening.innsending;
 
-import static org.slf4j.LoggerFactory.getLogger;
-
-import java.security.SecureRandom;
-import java.util.List;
-import java.util.Random;
-
-import org.slf4j.Logger;
-import org.springframework.stereotype.Service;
-
 import no.nav.foreldrepenger.common.domain.Kvittering;
-import no.nav.foreldrepenger.common.domain.felles.VedleggReferanse;
 import no.nav.foreldrepenger.selvbetjening.http.RetryAware;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.EttersendingFrontend;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.MutableVedleggReferanse;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.SøknadFrontend;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.VedleggFrontend;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.tilbakebetaling.TilbakebetalingUttalelse;
 import no.nav.foreldrepenger.selvbetjening.innsending.pdf.PdfGenerator;
 import no.nav.foreldrepenger.selvbetjening.mellomlagring.KryptertMellomlagring;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.Random;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 @Service
 public class InnsendingTjeneste implements RetryAware {
@@ -80,8 +79,8 @@ public class InnsendingTjeneste implements RetryAware {
             e.brukerTekst());
     }
 
-    private static VedleggReferanse id() {
-        return new VedleggReferanse("V" + IDGENERATOR.nextLong());
+    private static MutableVedleggReferanse id() {
+        return new MutableVedleggReferanse("V" + IDGENERATOR.nextLong());
     }
 
     public void hentMellomlagredeFiler(List<VedleggFrontend> vedlegg) {

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/VedleggsHåndteringTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/VedleggsHåndteringTjeneste.java
@@ -46,6 +46,7 @@ public class VedleggsHåndteringTjeneste {
         if (søknad.getVedlegg().isEmpty()) {
             return søknad;
         }
+        long start = System.currentTimeMillis();
         var duplisertVedleggReferanseTilEksisterendeVedleggReferanseMapping = new HashMap<MutableVedleggReferanse, MutableVedleggReferanse>();
         var unikeVedlegg = new ArrayList<VedleggFrontend>();
         var alleVedleggMedInnhold = hentUnikeVedleggMedInnhold(søknad.getVedlegg());
@@ -66,7 +67,8 @@ public class VedleggsHåndteringTjeneste {
 
         erstattAlleReferanserSomErDuplikater(søknad, duplisertVedleggReferanseTilEksisterendeVedleggReferanseMapping);
         erstattGammelVedleggslisteMedNyUtenDuplikater(søknad, unikeVedlegg);
-        LOG.info("Fjerner {} dupliserte vedlegg av totalt {} mottatt.", alleVedleggMedInnhold.size() - unikeVedlegg.size(), alleVedleggMedInnhold.size());
+        long finish = System.currentTimeMillis();
+        LOG.info("Fjerner {} dupliserte vedlegg av totalt {} mottatt ({}ms).", alleVedleggMedInnhold.size() - unikeVedlegg.size(), alleVedleggMedInnhold.size(), finish - start);
         return søknad;
     }
 

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/VedleggsHåndteringTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/VedleggsHåndteringTjeneste.java
@@ -46,7 +46,7 @@ public class VedleggsHåndteringTjeneste {
         if (søknad.getVedlegg().isEmpty()) {
             return søknad;
         }
-        var nyReferanseMapping = new HashMap<MutableVedleggReferanse, MutableVedleggReferanse>();
+        var duplisertVedleggReferanseTilEksisterendeVedleggReferanseMapping = new HashMap<MutableVedleggReferanse, MutableVedleggReferanse>();
         var unikeVedlegg = new ArrayList<VedleggFrontend>();
         var alleVedleggMedInnhold = hentUnikeVedleggMedInnhold(søknad.getVedlegg());
 
@@ -54,19 +54,19 @@ public class VedleggsHåndteringTjeneste {
             var vedleggEksistererAllerede = unikeVedlegg.stream()
                     .filter(v -> Objects.equals(vedlegg.getInnsendingsType(), v.getInnsendingsType()))
                     .filter(v -> Objects.equals(vedlegg.getSkjemanummer(), v.getSkjemanummer()))
-                    .filter(v -> Arrays.equals(v.getContent(), vedlegg.getContent()))
+                    .filter(v -> Arrays.equals(vedlegg.getContent(), v.getContent()))
                     .findFirst();
 
             if (vedleggEksistererAllerede.isPresent()) {
-                nyReferanseMapping.put(vedlegg.getId(), vedleggEksistererAllerede.get().getId());
+                duplisertVedleggReferanseTilEksisterendeVedleggReferanseMapping.put(vedlegg.getId(), vedleggEksistererAllerede.get().getId());
             } else {
                 unikeVedlegg.add(vedlegg);
             }
         }
 
-        erstattAlleReferanserSomErDuplikater(søknad, nyReferanseMapping);
+        erstattAlleReferanserSomErDuplikater(søknad, duplisertVedleggReferanseTilEksisterendeVedleggReferanseMapping);
         erstattGammelVedleggslisteMedNyUtenDuplikater(søknad, unikeVedlegg);
-        LOG.info("Fjerner {} dupliserte av totalt {} mottatt.", alleVedleggMedInnhold.size() - unikeVedlegg.size(), alleVedleggMedInnhold.size());
+        LOG.info("Fjerner {} dupliserte vedlegg av totalt {} mottatt.", alleVedleggMedInnhold.size() - unikeVedlegg.size(), alleVedleggMedInnhold.size());
         return søknad;
     }
 

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/VedleggsHåndteringTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/VedleggsHåndteringTjeneste.java
@@ -1,0 +1,123 @@
+package no.nav.foreldrepenger.selvbetjening.innsending;
+
+import static java.util.stream.Stream.concat;
+import static no.nav.foreldrepenger.common.util.StreamUtil.safeStream;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.EttersendingFrontend;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.ForeldrepengesøknadFrontend;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.MutableVedleggReferanse;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.SvangerskapspengesøknadFrontend;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.SøknadFrontend;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.VedleggFrontend;
+import no.nav.foreldrepenger.selvbetjening.vedlegg.Image2PDFConverter;
+
+@Component
+public class VedleggsHåndteringTjeneste {
+    private static final Logger LOG = LoggerFactory.getLogger(VedleggsHåndteringTjeneste.class);
+    private final Image2PDFConverter converter;
+
+    public VedleggsHåndteringTjeneste(Image2PDFConverter converter) {
+        this.converter = converter;
+    }
+
+    public EttersendingFrontend fjernDupliserteVedlegg(EttersendingFrontend ettersending) {
+        var alleVedlegg = ettersending.vedlegg();
+        var unikeVedlegg = alleVedlegg.stream()
+                .distinct()
+                .toList();
+
+        ettersending.vedlegg(unikeVedlegg);
+
+        LOG.info("Fjerner {} dupliserte av totalt {} mottatt.", alleVedlegg.size() - unikeVedlegg.size(), alleVedlegg.size());
+        return ettersending;
+    }
+
+    public SøknadFrontend fjernDupliserteVedlegg(SøknadFrontend søknad) {
+        if (søknad.getVedlegg().isEmpty()) {
+            return søknad;
+        }
+        var nyReferanseMapping = new HashMap<MutableVedleggReferanse, MutableVedleggReferanse>();
+        var unikeVedlegg = new ArrayList<VedleggFrontend>();
+        var alleVedleggMedInnhold = hentUnikeVedleggMedInnhold(søknad.getVedlegg());
+
+        for (var vedlegg : alleVedleggMedInnhold) {
+            var vedleggEksistererAllerede = unikeVedlegg.stream()
+                    .filter(v -> Objects.equals(vedlegg.getInnsendingsType(), v.getInnsendingsType()))
+                    .filter(v -> Objects.equals(vedlegg.getSkjemanummer(), v.getSkjemanummer()))
+                    .filter(v -> Arrays.equals(v.getContent(), vedlegg.getContent()))
+                    .findFirst();
+
+            if (vedleggEksistererAllerede.isPresent()) {
+                nyReferanseMapping.put(vedlegg.getId(), vedleggEksistererAllerede.get().getId());
+            } else {
+                unikeVedlegg.add(vedlegg);
+            }
+        }
+
+        erstattAlleReferanserSomErDuplikater(søknad, nyReferanseMapping);
+        erstattGammelVedleggslisteMedNyUtenDuplikater(søknad, unikeVedlegg);
+        LOG.info("Fjerner {} dupliserte av totalt {} mottatt.", alleVedleggMedInnhold.size() - unikeVedlegg.size(), alleVedleggMedInnhold.size());
+        return søknad;
+    }
+
+    private static void erstattGammelVedleggslisteMedNyUtenDuplikater(SøknadFrontend søknad, ArrayList<VedleggFrontend> unikeVedlegg) {
+        søknad.setVedlegg(unikeVedlegg.stream().toList());
+    }
+
+    private static void erstattAlleReferanserSomErDuplikater(SøknadFrontend søknad, HashMap<MutableVedleggReferanse, MutableVedleggReferanse> nyReferanseMapping) {
+        for (var gammelReferanse : nyReferanseMapping.entrySet()) {
+            var søker = søknad.getSøker();
+            søker.selvstendigNæringsdrivendeInformasjon().stream()
+                    .flatMap(sn -> sn.vedlegg().stream())
+                    .filter(v -> v.equals(gammelReferanse.getKey()))
+                    .forEach(v -> v.referanse(gammelReferanse.getValue().referanse()));
+
+            søker.andreInntekterSiste10Mnd().stream()
+                    .flatMap(a -> a.vedlegg().stream())
+                    .filter(v -> v.equals(gammelReferanse.getKey()))
+                    .forEach(v -> v.referanse(gammelReferanse.getValue().referanse()));
+
+            var barn = søknad.getBarn();
+            concat(barn.terminbekreftelse().stream(),
+                    concat(barn.adopsjonsvedtak().stream(),
+                    concat(barn.omsorgsovertakelse().stream(), barn.dokumentasjonAvAleneomsorg().stream())))
+                    .filter(v -> v.equals(gammelReferanse.getKey()))
+                    .forEach(v -> v.referanse(gammelReferanse.getValue().referanse()));
+
+            if (søknad instanceof ForeldrepengesøknadFrontend fpSøknad) {
+                fpSøknad.getUttaksplan().stream()
+                        .flatMap(uttaksplanPeriode -> uttaksplanPeriode.vedlegg().stream())
+                        .filter(v -> v.equals(gammelReferanse.getKey()))
+                        .forEach(v -> v.referanse(gammelReferanse.getValue().referanse()));
+            } else if (søknad instanceof SvangerskapspengesøknadFrontend svpSøknad) {
+                svpSøknad.getTilrettelegging().stream()
+                        .flatMap(t -> t.vedlegg().stream())
+                        .filter(v -> v.equals(gammelReferanse.getKey()))
+                        .forEach(v -> v.referanse(gammelReferanse.getValue().referanse()));
+            }
+        }
+    }
+
+    private List<VedleggFrontend> hentUnikeVedleggMedInnhold(List<VedleggFrontend> vedleggFrontend) {
+        return safeStream(vedleggFrontend).distinct().map(this::convert).toList();
+    }
+
+    private VedleggFrontend convert(VedleggFrontend v) {
+        VedleggFrontend vedlegg = v.kopi();
+        if ((v.getContent() != null) && (v.getContent().length > 0)) {
+            vedlegg.setContent(converter.convert(v.getContent()));
+        }
+        return vedlegg;
+    }
+
+}

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/BarnFrontend.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/BarnFrontend.java
@@ -1,40 +1,38 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.domain;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
-import static java.util.Collections.emptyList;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Digits;
-import jakarta.validation.constraints.Size;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import no.nav.foreldrepenger.common.domain.felles.VedleggReferanse;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+import static java.util.Collections.emptyList;
 
 @JsonInclude(NON_EMPTY)
 public record BarnFrontend(@Valid @Size(max = 10) List<LocalDate> fødselsdatoer,
                            @Digits(integer = 2, fraction = 0) int antallBarn,
-                           @Valid @Size(max = 15) List<VedleggReferanse> terminbekreftelse,
+                           @Valid @Size(max = 15) List<MutableVedleggReferanse> terminbekreftelse,
                            LocalDate termindato,
                            LocalDate terminbekreftelseDato,
                            LocalDate adopsjonsdato,
-                           @Valid @Size(max = 15) List<VedleggReferanse> adopsjonsvedtak,
+                           @Valid @Size(max = 15) List<MutableVedleggReferanse> adopsjonsvedtak,
                            LocalDate ankomstdato,
                            boolean adopsjonAvEktefellesBarn,
                            boolean søkerAdopsjonAlene,
                            LocalDate foreldreansvarsdato,
-                           @Valid @Size(max = 15) List<VedleggReferanse> omsorgsovertakelse,
-                           @Valid @Size(max = 15) List<VedleggReferanse> dokumentasjonAvAleneomsorg) {
+                           @Valid @Size(max = 15) List<MutableVedleggReferanse> omsorgsovertakelse,
+                           @Valid @Size(max = 15) List<MutableVedleggReferanse> dokumentasjonAvAleneomsorg) {
 
-    public BarnFrontend(List<LocalDate> fødselsdatoer, int antallBarn, List<VedleggReferanse> terminbekreftelse, LocalDate termindato,
-                        LocalDate terminbekreftelseDato, LocalDate adopsjonsdato, List<VedleggReferanse> adopsjonsvedtak,
+    public BarnFrontend(List<LocalDate> fødselsdatoer, int antallBarn, List<MutableVedleggReferanse> terminbekreftelse, LocalDate termindato,
+                        LocalDate terminbekreftelseDato, LocalDate adopsjonsdato, List<MutableVedleggReferanse> adopsjonsvedtak,
                         LocalDate ankomstdato, boolean adopsjonAvEktefellesBarn, boolean søkerAdopsjonAlene,
-                        LocalDate foreldreansvarsdato, List<VedleggReferanse> omsorgsovertakelse, List<VedleggReferanse> dokumentasjonAvAleneomsorg) {
+                        LocalDate foreldreansvarsdato, List<MutableVedleggReferanse> omsorgsovertakelse, List<MutableVedleggReferanse> dokumentasjonAvAleneomsorg) {
         this.fødselsdatoer = fødselsdatoer;
         this.antallBarn = antallBarn;
         this.terminbekreftelse = Optional.ofNullable(terminbekreftelse).orElse(emptyList());
@@ -51,8 +49,8 @@ public record BarnFrontend(@Valid @Size(max = 10) List<LocalDate> fødselsdatoer
     }
 
     @JsonIgnore
-    public List<VedleggReferanse> getAlleVedlegg() {
-        List<VedleggReferanse> alleVedlegg = new ArrayList<>();
+    public List<MutableVedleggReferanse> getAlleVedlegg() {
+        List<MutableVedleggReferanse> alleVedlegg = new ArrayList<>();
         alleVedlegg.addAll(terminbekreftelse);
         alleVedlegg.addAll(omsorgsovertakelse);
         alleVedlegg.addAll(adopsjonsvedtak);

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/EttersendingFrontend.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/EttersendingFrontend.java
@@ -1,29 +1,83 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.domain;
 
-import static java.util.Collections.emptyList;
-import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.FRITEKST;
-
-import java.util.List;
-import java.util.Optional;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-
 import no.nav.foreldrepenger.common.domain.Saksnummer;
 
-public record EttersendingFrontend(@Pattern(regexp = FRITEKST) @NotNull String type,
-                                   @Valid Saksnummer saksnummer,
-                                   @Valid @Size(max = 40) List<VedleggFrontend> vedlegg,
-                                   @Valid BrukerTekst brukerTekst,
-                                   @Pattern(regexp = FRITEKST) String dialogId) {
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
-    public EttersendingFrontend(String type, Saksnummer saksnummer, List<VedleggFrontend> vedlegg, BrukerTekst brukerTekst, String dialogId) {
+import static java.util.Collections.emptyList;
+import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.FRITEKST;
+
+public final class EttersendingFrontend {
+    private final @Pattern(regexp = FRITEKST) @NotNull String type;
+    private final @Valid Saksnummer saksnummer;
+    private final @Valid BrukerTekst brukerTekst;
+    private final @Pattern(regexp = FRITEKST) String dialogId;
+    private @Valid @Size(max = 40) List<VedleggFrontend> vedlegg;
+
+
+    public EttersendingFrontend(String type, Saksnummer saksnummer, BrukerTekst brukerTekst, String dialogId,  List<VedleggFrontend> vedlegg) {
         this.type = type;
         this.saksnummer = saksnummer;
-        this.vedlegg = Optional.ofNullable(vedlegg).orElse(emptyList());
         this.brukerTekst = brukerTekst;
         this.dialogId = dialogId;
+        this.vedlegg = Optional.ofNullable(vedlegg).orElse(emptyList());
     }
+
+    public String type() {
+        return type;
+    }
+
+    public Saksnummer saksnummer() {
+        return saksnummer;
+    }
+
+    public List<VedleggFrontend> vedlegg() {
+        return vedlegg;
+    }
+
+    public void vedlegg(List<VedleggFrontend> vedlegg) {
+        this.vedlegg = vedlegg;
+    }
+
+    public BrukerTekst brukerTekst() {
+        return brukerTekst;
+    }
+
+    public String dialogId() {
+        return dialogId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (EttersendingFrontend) obj;
+        return Objects.equals(this.type, that.type) &&
+                Objects.equals(this.saksnummer, that.saksnummer) &&
+                Objects.equals(this.vedlegg, that.vedlegg) &&
+                Objects.equals(this.brukerTekst, that.brukerTekst) &&
+                Objects.equals(this.dialogId, that.dialogId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, saksnummer, vedlegg, brukerTekst, dialogId);
+    }
+
+    @Override
+    public String toString() {
+        return "EttersendingFrontend[" +
+                "type=" + type + ", " +
+                "saksnummer=" + saksnummer + ", " +
+                "vedlegg=" + vedlegg + ", " +
+                "brukerTekst=" + brukerTekst + ", " +
+                "dialogId=" + dialogId + ']';
+    }
+
 }

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/MutableVedleggReferanse.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/MutableVedleggReferanse.java
@@ -1,0 +1,47 @@
+package no.nav.foreldrepenger.selvbetjening.innsending.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import java.util.Objects;
+
+public final class MutableVedleggReferanse {
+
+    @JsonValue
+    private @NotNull @Pattern(regexp = "^[\\p{Digit}\\p{L}-_]*$") String referanse;
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public MutableVedleggReferanse(@NotNull @Pattern(regexp = "^[\\p{Digit}\\p{L}-_]*$") String referanse) {
+        this.referanse = referanse;
+    }
+
+    public String referanse() {
+        return referanse;
+    }
+
+    public void referanse(String referanse) {
+        this.referanse = referanse;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (MutableVedleggReferanse) obj;
+        return Objects.equals(this.referanse, that.referanse);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(referanse);
+    }
+
+    @Override
+    public String toString() {
+        return "MutableVedleggReferanse[" +
+                "referanse=" + referanse + ']';
+    }
+
+}

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/SøkerFrontend.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/SøkerFrontend.java
@@ -1,18 +1,17 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.domain;
 
-import static java.util.Collections.emptyList;
-
-import java.util.List;
-import java.util.Optional;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
-
 import no.nav.foreldrepenger.common.domain.BrukerRolle;
 import no.nav.foreldrepenger.common.oppslag.dkif.Målform;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.arbeid.AnnenInntektFrontend;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.arbeid.FrilansInformasjonFrontend;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.arbeid.SelvstendigNæringsdrivendeInformasjonFrontend;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
 
 public record SøkerFrontend(BrukerRolle rolle,
                             Målform språkkode,

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/SøknadFrontend.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/SøknadFrontend.java
@@ -1,23 +1,22 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.domain;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
-import static java.util.Collections.emptyList;
-import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.BARE_BOKSTAVER;
-import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.FRITEKST;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import no.nav.foreldrepenger.common.domain.Saksnummer;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Pattern;
-import no.nav.foreldrepenger.common.domain.Saksnummer;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
+import static java.util.Collections.emptyList;
+import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.BARE_BOKSTAVER;
+import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.FRITEKST;
 
 
 @JsonTypeInfo(use = NAME, property = "type", visible = true)
@@ -47,7 +46,7 @@ public abstract sealed class SøknadFrontend permits EngangsstønadFrontend, For
     @Pattern(regexp = FRITEKST)
     private final String tilleggsopplysninger;
     @VedlegglistestørrelseConstraint
-    private final List<@Valid VedleggFrontend> vedlegg;
+    private List<@Valid VedleggFrontend> vedlegg;
 
     @JsonCreator
     protected SøknadFrontend(LocalDateTime opprettet, String type, Saksnummer saksnummer, SøkerFrontend søker, BarnFrontend barn,
@@ -112,6 +111,10 @@ public abstract sealed class SøknadFrontend permits EngangsstønadFrontend, For
 
     public List<VedleggFrontend> getVedlegg() {
         return vedlegg;
+    }
+
+    public void setVedlegg(List<VedleggFrontend> vedlegg) {
+        this.vedlegg = vedlegg;
     }
 
     @Override

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/UttaksplanPeriode.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/UttaksplanPeriode.java
@@ -1,20 +1,18 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.domain;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
-import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.BARE_BOKSTAVER;
-import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.FRITEKST;
-import static no.nav.foreldrepenger.common.util.StringUtil.maskListe;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Pattern;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import no.nav.foreldrepenger.common.domain.felles.VedleggReferanse;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.BARE_BOKSTAVER;
+import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.FRITEKST;
+import static no.nav.foreldrepenger.common.util.StringUtil.maskListe;
 
 // TODO: Skriv om til superklasse og subklasser basert på type
 @JsonInclude(NON_EMPTY)
@@ -22,12 +20,12 @@ public record UttaksplanPeriode(@Pattern(regexp = BARE_BOKSTAVER) String type,
                                 Double samtidigUttakProsent,
                                 Double stillingsprosent,
                                 List<@Pattern(regexp = FRITEKST) String> orgnumre,
-                                @Valid List<VedleggReferanse> vedlegg, // en vedleggsID
+                                List<@Valid MutableVedleggReferanse> vedlegg, // en vedleggsID
                                 @Pattern(regexp = BARE_BOKSTAVER) String forelder,
                                 @Pattern(regexp = "^[\\p{Digit}\\p{L}_]*$") String konto,
                                 @Pattern(regexp = "^[\\p{Digit}\\p{L}_]*$") String morsAktivitetIPerioden,
                                 @Pattern(regexp = "^[\\p{Digit}\\p{L}_]*$") String årsak,
-                                Tidsperiode tidsperiode,
+                                @Valid Tidsperiode tidsperiode,
                                 boolean erArbeidstaker,
                                 boolean erFrilanser,
                                 boolean erSelvstendig,
@@ -39,7 +37,7 @@ public record UttaksplanPeriode(@Pattern(regexp = BARE_BOKSTAVER) String type,
 
     @JsonCreator
     public UttaksplanPeriode(String type, Double samtidigUttakProsent, Double stillingsprosent, List<String> orgnumre,
-                             List<VedleggReferanse> vedlegg, String forelder, String konto, String morsAktivitetIPerioden,
+                             List<MutableVedleggReferanse> vedlegg, String forelder, String konto, String morsAktivitetIPerioden,
                              String årsak, Tidsperiode tidsperiode, boolean erArbeidstaker,
                              boolean erFrilanser, boolean erSelvstendig, boolean graderingInnvilget, boolean gradert,
                              boolean ønskerFlerbarnsdager, boolean ønskerSamtidigUttak, Boolean justeresVedFødsel) {

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/VedleggFrontend.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/VedleggFrontend.java
@@ -5,11 +5,10 @@ import static no.nav.foreldrepenger.common.domain.validation.InputValideringRege
 import java.net.URI;
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import no.nav.foreldrepenger.common.domain.felles.VedleggReferanse;
 
 public class VedleggFrontend {
 
@@ -18,7 +17,7 @@ public class VedleggFrontend {
     private final String beskrivelse;
 
     @Valid
-    private final VedleggReferanse id;
+    private final MutableVedleggReferanse id;
     @Pattern(regexp = "^[\\p{Digit}\\p{L}_]*$")
     private final String innsendingsType;
     @Pattern(regexp = "^[\\p{Digit}\\p{L}]*$")
@@ -27,12 +26,12 @@ public class VedleggFrontend {
     private final String uuid;
     private final URI url;
 
-    public VedleggFrontend(byte[] content, String beskrivelse, VedleggReferanse id, String skjemanummer) {
+    public VedleggFrontend(byte[] content, String beskrivelse, MutableVedleggReferanse id, String skjemanummer) {
         this(content, beskrivelse, id, null, skjemanummer, null, null);
     }
 
     @JsonCreator
-    public VedleggFrontend(byte[] content, String beskrivelse, VedleggReferanse id, String innsendingsType, String skjemanummer, String uuid, URI url) {
+    public VedleggFrontend(byte[] content, String beskrivelse, MutableVedleggReferanse id, String innsendingsType, String skjemanummer, String uuid, URI url) {
         this.content = content;
         this.beskrivelse = beskrivelse;
         this.id = id;
@@ -64,7 +63,7 @@ public class VedleggFrontend {
         return beskrivelse;
     }
 
-    public VedleggReferanse getId() {
+    public MutableVedleggReferanse getId() {
         return id;
     }
 

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/arbeid/AnnenInntektFrontend.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/arbeid/AnnenInntektFrontend.java
@@ -1,21 +1,19 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.domain.arbeid;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-import static java.util.Collections.emptyList;
-import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.BARE_BOKSTAVER;
-import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.FRITEKST;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.MutableVedleggReferanse;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.Tidsperiode;
 
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-
-import no.nav.foreldrepenger.common.domain.felles.VedleggReferanse;
-import no.nav.foreldrepenger.selvbetjening.innsending.domain.Tidsperiode;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static java.util.Collections.emptyList;
+import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.BARE_BOKSTAVER;
+import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.FRITEKST;
 
 @JsonInclude(NON_NULL)
 public record AnnenInntektFrontend(@Pattern(regexp = "^[\\p{L}_]*$") String type,       // TODO: AnnenOpptjeningType enum, men håndtere ikke null.
@@ -23,10 +21,10 @@ public record AnnenInntektFrontend(@Pattern(regexp = "^[\\p{L}_]*$") String type
                                    @Pattern(regexp = FRITEKST) String arbeidsgiverNavn,
                                    @Valid Tidsperiode tidsperiode,
                                    boolean erNærVennEllerFamilieMedArbeisdgiver,
-                                   @Valid @Size(max = 15) List<VedleggReferanse> vedlegg) {
+                                   @Valid @Size(max = 15) List<MutableVedleggReferanse> vedlegg) {
 
     public AnnenInntektFrontend(String type, String land, String arbeidsgiverNavn, Tidsperiode tidsperiode,
-                                boolean erNærVennEllerFamilieMedArbeisdgiver, List<VedleggReferanse> vedlegg) {
+                                boolean erNærVennEllerFamilieMedArbeisdgiver, List<MutableVedleggReferanse> vedlegg) {
         this.type = type;
         this.land = land;
         this.arbeidsgiverNavn = arbeidsgiverNavn;

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/arbeid/SelvstendigNæringsdrivendeInformasjonFrontend.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/arbeid/SelvstendigNæringsdrivendeInformasjonFrontend.java
@@ -1,20 +1,19 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.domain.arbeid;
 
-import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.BARE_BOKSTAVER;
-import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.FRITEKST;
-import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.ORGNUMMER;
-
-import java.time.LocalDate;
-import java.util.List;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-
-import no.nav.foreldrepenger.common.domain.felles.VedleggReferanse;
 import no.nav.foreldrepenger.common.domain.felles.opptjening.Virksomhetstype;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.MutableVedleggReferanse;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.Tidsperiode;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.BARE_BOKSTAVER;
+import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.FRITEKST;
+import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.ORGNUMMER;
 
 public record SelvstendigNæringsdrivendeInformasjonFrontend(
     boolean harBlittYrkesaktivILøpetAvDeTreSisteFerdigliknedeÅrene,
@@ -23,7 +22,7 @@ public record SelvstendigNæringsdrivendeInformasjonFrontend(
     @Digits(integer = 3, fraction = 2) Double stillingsprosent,
     @Digits(integer = 9, fraction = 0) int næringsinntekt,
     @Valid @Size(max = 10) List<Virksomhetstype> næringstyper,
-    @Valid @Size(max = 15) List<VedleggReferanse> vedlegg,
+    @Valid @Size(max = 15) List<MutableVedleggReferanse> vedlegg,
     LocalDate oppstartsdato,
     @Valid NæringsinntektInformasjonFrontend endringAvNæringsinntektInformasjon,
     @Pattern(regexp = FRITEKST) String navnPåNæringen,

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/tilrettelegging/Tilrettelegging.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/domain/tilrettelegging/Tilrettelegging.java
@@ -1,19 +1,18 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.domain.tilrettelegging;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
-import static java.util.Collections.emptyList;
-import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.BARE_BOKSTAVER;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.MutableVedleggReferanse;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Pattern;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import no.nav.foreldrepenger.common.domain.felles.VedleggReferanse;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+import static java.util.Collections.emptyList;
+import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.BARE_BOKSTAVER;
 
 @JsonInclude(NON_EMPTY)
 public record Tilrettelegging(@Pattern(regexp = BARE_BOKSTAVER) String type,
@@ -22,12 +21,12 @@ public record Tilrettelegging(@Pattern(regexp = BARE_BOKSTAVER) String type,
                               LocalDate behovForTilretteleggingFom,
                               LocalDate tilrettelagtArbeidFom,
                               LocalDate slutteArbeidFom,
-                              List<VedleggReferanse> vedlegg) {
+                              List<MutableVedleggReferanse> vedlegg) {
 
     @JsonCreator
     public Tilrettelegging(String type, Arbeidsforhold arbeidsforhold, Double stillingsprosent,
                            LocalDate behovForTilretteleggingFom, LocalDate tilrettelagtArbeidFom,
-                           LocalDate slutteArbeidFom, List<VedleggReferanse> vedlegg) {
+                           LocalDate slutteArbeidFom, List<MutableVedleggReferanse> vedlegg) {
         this.type = type;
         this.arbeidsforhold = arbeidsforhold;
         this.stillingsprosent = stillingsprosent;

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/EngangsstønadMapper.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/EngangsstønadMapper.java
@@ -1,17 +1,17 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.mapper;
 
-import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilMedlemskap;
-import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilRelasjonTilBarn;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-
 import no.nav.foreldrepenger.common.domain.BrukerRolle;
 import no.nav.foreldrepenger.common.domain.Søker;
 import no.nav.foreldrepenger.common.domain.Søknad;
 import no.nav.foreldrepenger.common.domain.Ytelse;
 import no.nav.foreldrepenger.common.domain.engangsstønad.Engangsstønad;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.EngangsstønadFrontend;
+
+import java.time.LocalDate;
+
+import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilMedlemskap;
+import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilRelasjonTilBarn;
+import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilVedlegg;
 
 final class EngangsstønadMapper {
 
@@ -24,7 +24,7 @@ final class EngangsstønadMapper {
             tilSøker(e),
             tilYtelse(e),
             e.getTilleggsopplysninger(),
-            new ArrayList<>() // Settes av InnsendingConnection etter logging
+            tilVedlegg(e.getVedlegg())
         );
     }
 

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/EttersendingMapper.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/EttersendingMapper.java
@@ -1,9 +1,9 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.mapper;
 
-import java.util.ArrayList;
-
 import no.nav.foreldrepenger.common.domain.felles.EttersendingsType;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.EttersendingFrontend;
+
+import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilVedlegg;
 
 public final class EttersendingMapper {
 
@@ -14,7 +14,7 @@ public final class EttersendingMapper {
         return new no.nav.foreldrepenger.common.domain.felles.Ettersending(
             ettersending.saksnummer(),
             EttersendingsType.valueOf(ettersending.type().toUpperCase()),
-            new ArrayList<>(),
+            tilVedlegg(ettersending.vedlegg()),
             ettersending.dialogId());
     }
 }

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/ForeldrepengerMapper.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/ForeldrepengerMapper.java
@@ -1,14 +1,5 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.mapper;
 
-import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilAnnenForelder;
-import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilMedlemskap;
-import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilOpptjening;
-import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilRelasjonTilBarn;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-
 import no.nav.foreldrepenger.common.domain.Søker;
 import no.nav.foreldrepenger.common.domain.Søknad;
 import no.nav.foreldrepenger.common.domain.felles.ProsentAndel;
@@ -32,6 +23,16 @@ import no.nav.foreldrepenger.common.domain.foreldrepenger.fordeling.UttaksPeriod
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.ForeldrepengesøknadFrontend;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.UttaksplanPeriode;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilAnnenForelder;
+import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilMedlemskap;
+import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilOpptjening;
+import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilRelasjonTilBarn;
+import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilVedlegg;
+import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilVedleggsreferanse;
+
 final class ForeldrepengerMapper {
 
     private ForeldrepengerMapper() {
@@ -44,7 +45,7 @@ final class ForeldrepengerMapper {
                 tilSøker(foreldrepengesøknad),
                 tilYtelse(foreldrepengesøknad),
                 foreldrepengesøknad.getTilleggsopplysninger(),
-                new ArrayList<>(),  // Settes av InnsendingConnection etter logging
+                tilVedlegg(foreldrepengesøknad.getVedlegg()),
                 foreldrepengesøknad.getSaksnummer());
         }
         return new Søknad(
@@ -52,7 +53,7 @@ final class ForeldrepengerMapper {
             tilSøker(foreldrepengesøknad),
             tilYtelse(foreldrepengesøknad),
             foreldrepengesøknad.getTilleggsopplysninger(),
-            new ArrayList<>() // Settes av InnsendingConnection etter logging
+            tilVedlegg(foreldrepengesøknad.getVedlegg())
         );
     }
 
@@ -121,7 +122,7 @@ final class ForeldrepengerMapper {
             u.tidsperiode().tom(),
             u.årsak() != null ? Overføringsårsak.valueOf(u.årsak()) : null,
             StønadskontoType.valueSafelyOf(u.konto()),
-            u.vedlegg()
+            tilVedleggsreferanse(u.vedlegg())
         );
     }
 
@@ -132,7 +133,7 @@ final class ForeldrepengerMapper {
             u.erArbeidstaker(),
             UtsettelsesÅrsak.valueOf(u.årsak()),
             u.morsAktivitetIPerioden() != null ? MorsAktivitet.valueOf(u.morsAktivitetIPerioden()) : null,
-            u.vedlegg()
+            tilVedleggsreferanse(u.vedlegg())
         );
     }
 
@@ -143,7 +144,7 @@ final class ForeldrepengerMapper {
             u.erArbeidstaker(),
             UtsettelsesÅrsak.valueOf(u.årsak()),
             u.morsAktivitetIPerioden() != null ? MorsAktivitet.valueOf(u.morsAktivitetIPerioden()) : null,
-            u.vedlegg()
+            tilVedleggsreferanse(u.vedlegg())
         );
     }
 
@@ -152,7 +153,7 @@ final class ForeldrepengerMapper {
             u.tidsperiode().fom(),
             u.tidsperiode().tom(),
             u.årsak() != null ? Oppholdsårsak.valueOf(u.årsak()) : null,
-            u.vedlegg()
+            tilVedleggsreferanse(u.vedlegg())
         );
     }
 
@@ -160,7 +161,7 @@ final class ForeldrepengerMapper {
         return new UttaksPeriode(
             u.tidsperiode().fom(),
             u.tidsperiode().tom(),
-            u.vedlegg(),
+            tilVedleggsreferanse(u.vedlegg()),
             StønadskontoType.valueSafelyOf(u.konto()),
             u.ønskerSamtidigUttak(),
             u.morsAktivitetIPerioden() != null ? MorsAktivitet.valueOf(u.morsAktivitetIPerioden()) : null,
@@ -174,7 +175,7 @@ final class ForeldrepengerMapper {
         return new GradertUttaksPeriode(
             u.tidsperiode().fom(),
             u.tidsperiode().tom(),
-            u.vedlegg(),
+            tilVedleggsreferanse(u.vedlegg()),
             StønadskontoType.valueSafelyOf(u.konto()),
             u.ønskerSamtidigUttak(),
             u.morsAktivitetIPerioden() != null ? MorsAktivitet.valueOf(u.morsAktivitetIPerioden()) : null,

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/SvangerskapspengerMapper.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/SvangerskapspengerMapper.java
@@ -1,14 +1,5 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.mapper;
 
-import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilMedlemskap;
-import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilOpptjening;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.springframework.util.CollectionUtils;
-
 import no.nav.foreldrepenger.common.domain.BrukerRolle;
 import no.nav.foreldrepenger.common.domain.Fødselsnummer;
 import no.nav.foreldrepenger.common.domain.Orgnummer;
@@ -26,6 +17,15 @@ import no.nav.foreldrepenger.common.domain.svangerskapspenger.tilrettelegging.ar
 import no.nav.foreldrepenger.common.domain.svangerskapspenger.tilrettelegging.arbeidsforhold.SelvstendigNæringsdrivende;
 import no.nav.foreldrepenger.common.domain.svangerskapspenger.tilrettelegging.arbeidsforhold.Virksomhet;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.SvangerskapspengesøknadFrontend;
+import org.springframework.util.CollectionUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilMedlemskap;
+import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilOpptjening;
+import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilVedlegg;
+import static no.nav.foreldrepenger.selvbetjening.innsending.mapper.CommonMapper.tilVedleggsreferanse;
 
 final class SvangerskapspengerMapper {
 
@@ -38,7 +38,7 @@ final class SvangerskapspengerMapper {
             tilSøker(s),
             tilYtelse(s),
             s.getTilleggsopplysninger(),
-            new ArrayList<>() // Settes av InnsendingConnection etter logging
+            tilVedlegg(s.getVedlegg())
         );
     }
 
@@ -87,7 +87,7 @@ final class SvangerskapspengerMapper {
             tilArbeidsforhold(tilrettelegging.arbeidsforhold()),
             tilrettelegging.behovForTilretteleggingFom(),
             tilrettelegging.slutteArbeidFom(),
-            tilrettelegging.vedlegg()
+            tilVedleggsreferanse(tilrettelegging.vedlegg())
         );
     }
 
@@ -97,7 +97,7 @@ final class SvangerskapspengerMapper {
             tilrettelegging.behovForTilretteleggingFom(),
             tilrettelegging.tilrettelagtArbeidFom(),
             tilrettelegging.stillingsprosent() != null ? ProsentAndel.valueOf(tilrettelegging.stillingsprosent()) : null,
-            tilrettelegging.vedlegg()
+            tilVedleggsreferanse(tilrettelegging.vedlegg())
         );
     }
 
@@ -106,7 +106,7 @@ final class SvangerskapspengerMapper {
             tilArbeidsforhold(tilrettelegging.arbeidsforhold()),
             tilrettelegging.behovForTilretteleggingFom(),
             tilrettelegging.tilrettelagtArbeidFom(),
-            tilrettelegging.vedlegg()
+            tilVedleggsreferanse(tilrettelegging.vedlegg())
         );
     }
 

--- a/src/test/java/no/nav/foreldrepenger/selvbetjening/SerializationTest.java
+++ b/src/test/java/no/nav/foreldrepenger/selvbetjening/SerializationTest.java
@@ -2,10 +2,10 @@ package no.nav.foreldrepenger.selvbetjening;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import no.nav.foreldrepenger.common.domain.felles.VedleggReferanse;
 import no.nav.foreldrepenger.selvbetjening.config.JacksonConfiguration;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.BarnFrontend;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.EngangsstønadFrontend;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.MutableVedleggReferanse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +29,7 @@ class SerializationTest {
     @Test
     void engangstonad_deserialisation() throws IOException {
         var barn = new BarnFrontend(null, 2,
-            List.of(new VedleggReferanse(LocalDate.now().minusWeeks(6).toString())),
+            List.of(new MutableVedleggReferanse(LocalDate.now().minusWeeks(6).toString())),
             LocalDate.now().minusWeeks(1), null,
             null, null, null, false, false,
             null, null, null);

--- a/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/VedleggsHåndteringTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/VedleggsHåndteringTjenesteTest.java
@@ -1,0 +1,122 @@
+package no.nav.foreldrepenger.selvbetjening.innsending;
+
+import static no.nav.foreldrepenger.common.util.ResourceHandleUtil.bytesFra;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import no.nav.foreldrepenger.selvbetjening.config.JacksonConfiguration;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.SøknadFrontend;
+import no.nav.foreldrepenger.selvbetjening.vedlegg.Image2PDFConverter;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = JacksonConfiguration.class)
+class VedleggsHåndteringTjenesteTest {
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    private final Image2PDFConverter converter = mock(Image2PDFConverter.class);
+
+    @BeforeEach
+    public void setup() {
+        when(converter.convert(any())).thenAnswer(i -> i.getArguments()[0]);
+    }
+
+    @Test
+    void søknadSkalVæreLikNårDetIkkeFinnesDupliserteVedlegg() throws IOException {
+        var søknadOrginal = mapper.readValue(bytesFra("json/foreldrepenger_adopsjon_annenInntekt.json"), SøknadFrontend.class);
+        var søknadDupliserteVedleggFjernet = mapper.readValue(bytesFra("json/foreldrepenger_adopsjon_annenInntekt.json"), SøknadFrontend.class); // For å ikke lage kopi
+
+        var vedleggsHåndteringsTjeneste = new VedleggsHåndteringTjeneste(converter);
+        vedleggsHåndteringsTjeneste.fjernDupliserteVedlegg(søknadDupliserteVedleggFjernet);
+
+        assertThat(søknadOrginal.getVedlegg()).hasSameSizeAs(søknadDupliserteVedleggFjernet.getVedlegg());
+        assertThat(søknadOrginal).isEqualTo(søknadDupliserteVedleggFjernet);
+    }
+
+    @Test
+    void fjernerDupliserteVedleggFraSøknad() throws IOException {
+        var søknadOrginal = mapper.readValue(bytesFra("json/foreldrepenger_adopsjon_annenInntekt_dupliserte_vedlegg.json"), SøknadFrontend.class);
+        var søknadDupliserteVedleggFjernet = mapper.readValue(bytesFra("json/foreldrepenger_adopsjon_annenInntekt_dupliserte_vedlegg.json"), SøknadFrontend.class); // For å ikke lage kopi
+
+        var vedleggsHåndteringsTjeneste = new VedleggsHåndteringTjeneste(converter);
+        vedleggsHåndteringsTjeneste.fjernDupliserteVedlegg(søknadDupliserteVedleggFjernet);
+
+        assertThat(søknadOrginal.getVedlegg()).hasSize(4);
+        assertThat(søknadOrginal.getBarn().omsorgsovertakelse().stream()
+                .distinct()
+                .count()).isEqualTo(3);
+        assertThat(søknadDupliserteVedleggFjernet.getVedlegg()).hasSize(2);
+        assertThat(søknadDupliserteVedleggFjernet.getBarn().omsorgsovertakelse().stream()
+                .distinct()
+                .count()).isEqualTo(1);
+    }
+
+    @Test
+    void fjernerDupliserteVedleggFraSøknadVedGradering() throws IOException {
+        var søknadOrginal = mapper.readValue(bytesFra("json/foreldrepenger_far_gardering_frilans_duplisert_vedlegg.json"), SøknadFrontend.class);
+        var søknadDupliserteVedleggFjernet = mapper.readValue(bytesFra("json/foreldrepenger_far_gardering_frilans_duplisert_vedlegg.json"), SøknadFrontend.class); // For å ikke lage kopi
+
+        var vedleggsHåndteringsTjeneste = new VedleggsHåndteringTjeneste(converter);
+        vedleggsHåndteringsTjeneste.fjernDupliserteVedlegg(søknadDupliserteVedleggFjernet);
+
+        assertThat(søknadOrginal.getVedlegg()).hasSize(2);
+        assertThat(søknadDupliserteVedleggFjernet.getVedlegg()).hasSize(1);
+        søknadDupliserteVedleggFjernet.setVedlegg(søknadOrginal.getVedlegg());
+        assertThat(søknadDupliserteVedleggFjernet).isEqualTo(søknadOrginal);
+    }
+
+    @Test
+    void skalIkkeFjerneVedleggDerHvorTypeSkjemaNummerErLiktMensInnholdErForskjellig() throws IOException {
+        var søknadOrginal = mapper.readValue(bytesFra("json/foreldrepenger_far_gardering_frilans_to_vedlegg_samme_type_ulikt_innhold.json"), SøknadFrontend.class);
+        var søknadDupliserteVedleggFjernet = mapper.readValue(bytesFra("json/foreldrepenger_far_gardering_frilans_to_vedlegg_samme_type_ulikt_innhold.json"), SøknadFrontend.class); // For å ikke lage kopi
+
+        var vedleggsHåndteringsTjeneste = new VedleggsHåndteringTjeneste(converter);
+        vedleggsHåndteringsTjeneste.fjernDupliserteVedlegg(søknadDupliserteVedleggFjernet);
+
+        assertThat(søknadDupliserteVedleggFjernet.getVedlegg()).hasSameSizeAs(søknadOrginal.getVedlegg());
+        assertThat(søknadDupliserteVedleggFjernet).isEqualTo(søknadOrginal);
+    }
+
+
+    @Test
+    void ettersendingerForblirUendretVedIngenDupliserteVedlegg() throws IOException {
+        var ettersendelseOrginal = mapper.readValue(bytesFra("json/ettersendelse_I000044.json"), SøknadFrontend.class);
+        var ettersendelseDupliserteVedleggFjernet = mapper.readValue(bytesFra("json/ettersendelse_I000044.json"), SøknadFrontend.class);
+
+        var vedleggsHåndteringsTjeneste = new VedleggsHåndteringTjeneste(converter);
+        vedleggsHåndteringsTjeneste.fjernDupliserteVedlegg(ettersendelseDupliserteVedleggFjernet);
+
+        assertThat(ettersendelseOrginal.getVedlegg()).hasSameSizeAs(ettersendelseDupliserteVedleggFjernet.getVedlegg());
+        assertThat(ettersendelseOrginal).isEqualTo(ettersendelseDupliserteVedleggFjernet);
+    }
+
+    @Test
+    void duplikateVedleggFjernesFraEttersending() throws IOException {
+        var ettersendelseOrginal = mapper.readValue(bytesFra("json/ettersendelse_I000044_duplikate_vedlegg.json"), SøknadFrontend.class);
+        var ettersendelseDupliserteVedleggFjernet = mapper.readValue(bytesFra("json/ettersendelse_I000044_duplikate_vedlegg.json"), SøknadFrontend.class);
+
+        var vedleggsHåndteringsTjeneste = new VedleggsHåndteringTjeneste(converter);
+        vedleggsHåndteringsTjeneste.fjernDupliserteVedlegg(ettersendelseDupliserteVedleggFjernet);
+
+        assertThat(ettersendelseOrginal.getVedlegg()).hasSize(3);
+        assertThat(ettersendelseDupliserteVedleggFjernet.getVedlegg()).hasSize(1);
+
+        ettersendelseDupliserteVedleggFjernet.setVedlegg(ettersendelseOrginal.getVedlegg());
+        assertThat(ettersendelseOrginal).isEqualTo(ettersendelseDupliserteVedleggFjernet);
+    }
+
+}

--- a/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/deseralisering/EttersendelseFrontendDeseraliseringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/deseralisering/EttersendelseFrontendDeseraliseringTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 
-import no.nav.foreldrepenger.common.domain.felles.VedleggReferanse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import no.nav.foreldrepenger.selvbetjening.config.JacksonConfiguration;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.EttersendingFrontend;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.MutableVedleggReferanse;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = JacksonConfiguration.class)
@@ -32,7 +32,7 @@ class EttersendelseFrontendDeseraliseringTest {
         assertThat(ettersendelse.saksnummer().value()).isEqualTo("352003201");
         assertThat(ettersendelse.vedlegg()).hasSize(1);
         var vedlegg = ettersendelse.vedlegg().get(0);
-        assertThat(vedlegg.getId()).isEqualTo(new VedleggReferanse("V090740687265315217194125674862219730"));
+        assertThat(vedlegg.getId()).isEqualTo(new MutableVedleggReferanse("V090740687265315217194125674862219730"));
         assertThat(vedlegg.getSkjemanummer()).isEqualTo("I000044");
         assertThat(vedlegg.getContent()).isNull();
         assertThat(vedlegg.getInnsendingsType()).isNull();

--- a/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/deseralisering/SøknadFrontendDeseraliseringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/deseralisering/SøknadFrontendDeseraliseringTest.java
@@ -11,8 +11,6 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
-import no.nav.foreldrepenger.common.domain.felles.VedleggReferanse;
-import no.nav.foreldrepenger.selvbetjening.innsending.domain.VedleggFrontend;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,15 +19,16 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import no.nav.foreldrepenger.common.domain.BrukerRolle;
 import no.nav.foreldrepenger.common.domain.felles.opptjening.Virksomhetstype;
 import no.nav.foreldrepenger.common.oppslag.dkif.Målform;
 import no.nav.foreldrepenger.selvbetjening.config.JacksonConfiguration;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.ForeldrepengesøknadFrontend;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.MutableVedleggReferanse;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.SøknadFrontend;
-
-import jakarta.validation.Validation;
-import jakarta.validation.Validator;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.VedleggFrontend;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = JacksonConfiguration.class)
@@ -163,7 +162,7 @@ class SøknadFrontendDeseraliseringTest {
         assertThat(vedleggListe).hasSize(1);
         var vedlegg = vedleggListe.get(0);
         assertThat(vedlegg.getSkjemanummer()).isEqualTo("I000044");
-        assertThat(vedlegg.getId()).isEqualTo(new VedleggReferanse("V090740687265315217194125674862219730"));
+        assertThat(vedlegg.getId()).isEqualTo(new MutableVedleggReferanse("V090740687265315217194125674862219730"));
         assertThat(vedlegg.getUrl()).isEqualTo(new URI("https://foreldrepengesoknad-api.intern.dev.nav.no/rest/storage/vedlegg/b9974360-6c07-4b9d-acac-14f0f417d200"));
     }
 
@@ -186,13 +185,13 @@ class SøknadFrontendDeseraliseringTest {
         List<VedleggFrontend>  sendSenere = new ArrayList<>();
 
         while (sendSenere.size() < sendSenereVedlegg) {
-            var nyttVedlegg = new VedleggFrontend(null, "Beskrivelse", new VedleggReferanse("Id"), "SEND_SENERE", "Skjemanummer", "xyz", null);
+            var nyttVedlegg = new VedleggFrontend(null, "Beskrivelse", new MutableVedleggReferanse("Id"), "SEND_SENERE", "Skjemanummer", "xyz", null);
             sendSenere.add(nyttVedlegg);
         }
 
         List<VedleggFrontend> opplastet = new ArrayList<>();
         while (opplastet.size() < opplastetVedlegg) {
-            var nyttVedlegg = new VedleggFrontend(null, "Beskrivelse", new VedleggReferanse("Id"), null, "Skjemanummer", "xyz", null);
+            var nyttVedlegg = new VedleggFrontend(null, "Beskrivelse", new MutableVedleggReferanse("Id"), null, "Skjemanummer", "xyz", null);
             opplastet.add(nyttVedlegg);
         }
         sendSenere.addAll(opplastet);

--- a/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/EngangstønadTilDtoMapperTest.java
+++ b/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/EngangstønadTilDtoMapperTest.java
@@ -18,6 +18,7 @@ import no.nav.foreldrepenger.common.domain.felles.relasjontilbarn.FremtidigFøds
 import no.nav.foreldrepenger.common.oppslag.dkif.Målform;
 import no.nav.foreldrepenger.selvbetjening.config.JacksonConfiguration;
 import no.nav.foreldrepenger.selvbetjening.innsending.InnsendingConnection;
+import no.nav.foreldrepenger.selvbetjening.innsending.VedleggsHåndteringTjeneste;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.EngangsstønadFrontend;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.SøknadFrontend;
 import no.nav.foreldrepenger.selvbetjening.vedlegg.Image2PDFConverter;
@@ -27,7 +28,7 @@ import no.nav.foreldrepenger.selvbetjening.vedlegg.Image2PDFConverter;
 @ContextConfiguration(classes = JacksonConfiguration.class)
 class EngangstønadTilDtoMapperTest {
 
-    private final InnsendingConnection connection = new InnsendingConnection(null, null, new Image2PDFConverter());
+    private final InnsendingConnection connection = new InnsendingConnection(null, null, new VedleggsHåndteringTjeneste(new Image2PDFConverter()));
 
     @Autowired
     private ObjectMapper mapper;

--- a/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/EttersendingTilDtoMapperTest.java
+++ b/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/EttersendingTilDtoMapperTest.java
@@ -18,6 +18,7 @@ import no.nav.foreldrepenger.common.domain.felles.DokumentType;
 import no.nav.foreldrepenger.common.domain.felles.EttersendingsType;
 import no.nav.foreldrepenger.selvbetjening.config.JacksonConfiguration;
 import no.nav.foreldrepenger.selvbetjening.innsending.InnsendingConnection;
+import no.nav.foreldrepenger.selvbetjening.innsending.VedleggsHåndteringTjeneste;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.EttersendingFrontend;
 import no.nav.foreldrepenger.selvbetjening.vedlegg.Image2PDFConverter;
 
@@ -26,7 +27,7 @@ import no.nav.foreldrepenger.selvbetjening.vedlegg.Image2PDFConverter;
 @ContextConfiguration(classes = JacksonConfiguration.class)
 class EttersendingTilDtoMapperTest {
 
-    private final InnsendingConnection connection = new InnsendingConnection(null, null, new Image2PDFConverter());
+    private final InnsendingConnection connection = new InnsendingConnection(null, null, new VedleggsHåndteringTjeneste(new Image2PDFConverter()));
 
     @Autowired
     private ObjectMapper mapper;

--- a/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/ForeldrepengeSøknadTilDtoMapperTest.java
+++ b/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/ForeldrepengeSøknadTilDtoMapperTest.java
@@ -1,20 +1,7 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.mapper;
 
-import static no.nav.foreldrepenger.common.util.ResourceHandleUtil.bytesFra;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.IOException;
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.neovisionaries.i18n.CountryCode;
-
 import no.nav.foreldrepenger.common.domain.BrukerRolle;
 import no.nav.foreldrepenger.common.domain.felles.ProsentAndel;
 import no.nav.foreldrepenger.common.domain.felles.relasjontilbarn.Adopsjon;
@@ -28,15 +15,27 @@ import no.nav.foreldrepenger.common.domain.foreldrepenger.fordeling.UtsettelsesP
 import no.nav.foreldrepenger.common.oppslag.dkif.Målform;
 import no.nav.foreldrepenger.selvbetjening.config.JacksonConfiguration;
 import no.nav.foreldrepenger.selvbetjening.innsending.InnsendingConnection;
+import no.nav.foreldrepenger.selvbetjening.innsending.VedleggsHåndteringTjeneste;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.ForeldrepengesøknadFrontend;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.SøknadFrontend;
 import no.nav.foreldrepenger.selvbetjening.vedlegg.Image2PDFConverter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.IOException;
+import java.util.List;
+
+import static no.nav.foreldrepenger.common.util.ResourceHandleUtil.bytesFra;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = JacksonConfiguration.class)
 class ForeldrepengeSøknadTilDtoMapperTest {
 
-    private final InnsendingConnection connection = new InnsendingConnection(null, null, new Image2PDFConverter());
+    private final InnsendingConnection connection = new InnsendingConnection(null, null, new VedleggsHåndteringTjeneste(new Image2PDFConverter()));
 
     @Autowired
     private ObjectMapper mapper;

--- a/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/SvangerskapspengesøknadTilDtoMapperTest.java
+++ b/src/test/java/no/nav/foreldrepenger/selvbetjening/innsending/mapper/SvangerskapspengesøknadTilDtoMapperTest.java
@@ -1,19 +1,6 @@
 package no.nav.foreldrepenger.selvbetjening.innsending.mapper;
 
-import static no.nav.foreldrepenger.common.util.ResourceHandleUtil.bytesFra;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.IOException;
-import java.time.LocalDate;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import no.nav.foreldrepenger.common.domain.BrukerRolle;
 import no.nav.foreldrepenger.common.domain.felles.ProsentAndel;
 import no.nav.foreldrepenger.common.domain.svangerskapspenger.Svangerskapspenger;
@@ -22,16 +9,28 @@ import no.nav.foreldrepenger.common.domain.svangerskapspenger.tilrettelegging.ar
 import no.nav.foreldrepenger.common.oppslag.dkif.Målform;
 import no.nav.foreldrepenger.selvbetjening.config.JacksonConfiguration;
 import no.nav.foreldrepenger.selvbetjening.innsending.InnsendingConnection;
+import no.nav.foreldrepenger.selvbetjening.innsending.VedleggsHåndteringTjeneste;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.SvangerskapspengesøknadFrontend;
 import no.nav.foreldrepenger.selvbetjening.innsending.domain.SøknadFrontend;
 import no.nav.foreldrepenger.selvbetjening.vedlegg.Image2PDFConverter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+import static no.nav.foreldrepenger.common.util.ResourceHandleUtil.bytesFra;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = JacksonConfiguration.class)
 class SvangerskapspengesøknadTilDtoMapperTest {
 
-    private final InnsendingConnection connection = new InnsendingConnection(null, null, new Image2PDFConverter());
+    private final InnsendingConnection connection = new InnsendingConnection(null, null, new VedleggsHåndteringTjeneste(new Image2PDFConverter()));
 
     @Autowired
     private ObjectMapper mapper;

--- a/src/test/java/no/nav/foreldrepenger/selvbetjening/vedlegg/VedleggSjekkerTest.java
+++ b/src/test/java/no/nav/foreldrepenger/selvbetjening/vedlegg/VedleggSjekkerTest.java
@@ -1,18 +1,14 @@
 package no.nav.foreldrepenger.selvbetjening.vedlegg;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.net.URI;
-import java.util.List;
-import java.util.Optional;
-
-import no.nav.foreldrepenger.common.domain.felles.VedleggReferanse;
+import no.nav.foreldrepenger.selvbetjening.innsending.InnsendingConnection;
+import no.nav.foreldrepenger.selvbetjening.innsending.InnsendingTjeneste;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.MutableVedleggReferanse;
+import no.nav.foreldrepenger.selvbetjening.innsending.domain.VedleggFrontend;
+import no.nav.foreldrepenger.selvbetjening.innsending.pdf.PdfGenerator;
+import no.nav.foreldrepenger.selvbetjening.mellomlagring.Attachment;
+import no.nav.foreldrepenger.selvbetjening.mellomlagring.KryptertMellomlagring;
+import no.nav.foreldrepenger.selvbetjening.vedlegg.virusscan.ClamAvVirusScanner;
+import no.nav.foreldrepenger.selvbetjening.vedlegg.virusscan.VirusScanConnection;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -21,14 +17,17 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
 import org.springframework.util.unit.DataSize;
 
-import no.nav.foreldrepenger.selvbetjening.innsending.InnsendingConnection;
-import no.nav.foreldrepenger.selvbetjening.innsending.InnsendingTjeneste;
-import no.nav.foreldrepenger.selvbetjening.innsending.domain.VedleggFrontend;
-import no.nav.foreldrepenger.selvbetjening.innsending.pdf.PdfGenerator;
-import no.nav.foreldrepenger.selvbetjening.mellomlagring.Attachment;
-import no.nav.foreldrepenger.selvbetjening.mellomlagring.KryptertMellomlagring;
-import no.nav.foreldrepenger.selvbetjening.vedlegg.virusscan.ClamAvVirusScanner;
-import no.nav.foreldrepenger.selvbetjening.vedlegg.virusscan.VirusScanConnection;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class VedleggSjekkerTest {
@@ -147,7 +146,7 @@ class VedleggSjekkerTest {
     private static VedleggFrontend vedlegg(int megabytes) {
         var uuid = "802e2ce7-8106-46cf-afdb-2aecc2b6de7c";
         var content = new byte[((int) DataSize.ofMegabytes(megabytes).toBytes())];
-        return new VedleggFrontend(content, "En stoooor pdf!", new VedleggReferanse("V00001"), null, "I000038", uuid, URI.create("https://foreldrepengesoknad-api.intern.dev.nav.no/" + uuid));
+        return new VedleggFrontend(content, "En stoooor pdf!", new MutableVedleggReferanse("V00001"), null, "I000038", uuid, URI.create("https://foreldrepengesoknad-api.intern.dev.nav.no/" + uuid));
     }
 
     private static byte[] fraResource(String classPathResource) throws IOException {

--- a/src/test/resources/json/ettersendelse_I000044_duplikate_vedlegg.json
+++ b/src/test/resources/json/ettersendelse_I000044_duplikate_vedlegg.json
@@ -1,0 +1,39 @@
+{
+    "saksnummer": "352003201",
+    "type": "foreldrepenger",
+    "vedlegg": [
+        {
+            "file": {},
+            "content": [10,9,8,7,6,5,4,3,2,1],
+            "filename": "logo_mwg.png.png",
+            "filesize": 10130,
+            "id": "V090740687265315217194125674862219730",
+            "pending": false,
+            "skjemanummer": "I000044",
+            "url": "https://foreldrepengesoknad-api.intern.dev.nav.no/rest/storage/vedlegg/b9974360-6c07-4b9d-acac-14f0f417d200",
+            "uuid": "b9974360-6c07-4b9d-acac-14f0f417d200"
+        },
+        {
+            "file": {},
+            "content": [10,9,8,7,6,5,4,3,2,1],
+            "filename": "23asd.png.png",
+            "filesize": 10130,
+            "id": "V090740687265315217194125674862219730",
+            "pending": false,
+            "skjemanummer": "I000044",
+            "url": "https://foreldrepengesoknad-api.intern.dev.nav.no/rest/storage/vedlegg/b9974360-6c07-4b9d-acac-14f0f417d200",
+            "uuid": "b9974360-6c07-4b9d-acac-14f0f417d200"
+        },
+        {
+            "file": {},
+            "content": [10,9,8,7,6,5,4,3,2,1],
+            "filename": "logo_mwg.png.png",
+            "filesize": 10130,
+            "id": "V090740687265315217194125674862219730",
+            "pending": false,
+            "skjemanummer": "I000044",
+            "url": "https://foreldrepengesoknad-api.intern.dev.nav.no/rest/storage/vedlegg/b9974360-6c07-4b9d-acac-14f0f417d200",
+            "uuid": "b9974360-6c07-4b9d-acac-14f0f417d200"
+        }
+    ]
+}

--- a/src/test/resources/json/foreldrepenger_adopsjon_annenInntekt_dupliserte_vedlegg.json
+++ b/src/test/resources/json/foreldrepenger_adopsjon_annenInntekt_dupliserte_vedlegg.json
@@ -1,0 +1,138 @@
+{
+    "annenForelder": {
+        "erInformertOmSøknaden": true,
+        "etternavn": "Pikkalau",
+        "fnr": "11111122222",
+        "fornavn": "Takkalu",
+        "harRettPåForeldrepenger": true,
+        "kanIkkeOppgis": false
+    },
+    "barn": {
+        "adopsjonAvEktefellesBarn": false,
+        "adopsjonsdato": "2022-01-03T00:00:00.000Z",
+        "adoptertIUtlandet": false,
+        "antallBarn": 2,
+        "fødselsdatoer": [
+            "2015-12-08T00:00:00.000Z",
+            "2017-12-06T00:00:00.000Z"
+        ],
+        "omsorgsovertakelse": [
+            "V2898513808905600871912527163003030700",
+            "V2898513808905600871912527163003030701",
+            "V2898513808905600871912527163003030702"
+        ]
+    },
+    "dekningsgrad": "100",
+    "erEndringssøknad": false,
+    "harGodkjentOppsummering": true,
+    "harGodkjentVilkår": true,
+    "informasjonOmUtenlandsopphold": {
+        "iNorgeNeste12Mnd": true,
+        "iNorgeSiste12Mnd": true,
+        "senereOpphold": [],
+        "tidligereOpphold": []
+    },
+    "situasjon": "adopsjon",
+    "søker": {
+        "andreInntekterSiste10Mnd": [
+            {
+                "arbeidsgiverNavn": "Annen AS",
+                "tidsperiode": {
+                    "fom": "2021-06-17T00:00:00.000Z",
+                    "tom": "2021-10-06T00:00:00.000Z"
+                },
+                "type": "VENTELØNN_VARTPENGER",
+                "vedlegg": [
+                    "V916003341575408784272146025402319232"
+                ]
+            }
+        ],
+        "erAleneOmOmsorg": false,
+        "harHattAnnenInntektSiste10Mnd": true,
+        "harJobbetSomFrilansSiste10Mnd": false,
+        "harJobbetSomSelvstendigNæringsdrivendeSiste10Mnd": false,
+        "rolle": "MOR",
+        "språkkode": "NB"
+    },
+    "type": "foreldrepenger",
+    "uttaksplan": [
+        {
+            "forelder": "mor",
+            "gradert": false,
+            "id": "64427353-4320-21926-8840-2647368550482",
+            "konto": "MØDREKVOTE",
+            "tidsperiode": {
+                "fom": "2022-01-03T00:00:00.000Z",
+                "tom": "2022-04-15T00:00:00.000Z"
+            },
+            "type": "uttak",
+            "ønskerSamtidigUttak": false
+        },
+        {
+            "forelder": "mor",
+            "gradert": false,
+            "id": "2117609557-9052-6026-1792-8457150146294",
+            "konto": "FELLESPERIODE",
+            "tidsperiode": {
+                "fom": "2022-04-18T00:00:00.000Z",
+                "tom": "2022-12-02T00:00:00.000Z"
+            },
+            "type": "uttak",
+            "ønskerSamtidigUttak": false
+        }
+    ],
+    "vedlegg": [
+        {
+            "file": {},
+            "content": [1,2,3,4,5,6,7,8,9,10],
+            "filename": "nav-logo-black.png",
+            "filesize": 1529,
+            "id": "V916003341575408784272146025402319232",
+            "pending": false,
+            "skjemanummer": "I000044",
+            "innsendingsType": "anneninntektDokumentasjon",
+            "uploaded": true,
+            "url": "https://foreldrepengesoknad-api.intern.dev.nav.no/rest/storage/vedlegg/d8bad0c1-f281-4a0b-a352-e61de4cbac33",
+            "uuid": "d8bad0c1-f281-4a0b-a352-e61de4cbac33"
+        },
+        {
+            "file": {},
+            "content": [10,9,8,7,6,5,4,3,2,1],
+            "filename": "logo_mwg.png.png",
+            "filesize": 10130,
+            "id": "V2898513808905600871912527163003030700",
+            "pending": false,
+            "skjemanummer": "I000042",
+            "innsendingsType": "omsorgsovertakelse",
+            "uploaded": true,
+            "url": "https://foreldrepengesoknad-api.intern.dev.nav.no/rest/storage/vedlegg/7005c937-8114-4af4-b19c-18143db92025",
+            "uuid": "7005c937-8114-4af4-b19c-18143db92025"
+        },
+        {
+            "file": {},
+            "content": [10,9,8,7,6,5,4,3,2,1],
+            "filename": "logo_mwg.png.png",
+            "filesize": 10130,
+            "id": "V2898513808905600871912527163003030701",
+            "pending": false,
+            "skjemanummer": "I000042",
+            "innsendingsType": "omsorgsovertakelse",
+            "uploaded": true,
+            "url": "https://foreldrepengesoknad-api.intern.dev.nav.no/rest/storage/vedlegg/7005c937-8114-4af4-b19c-18143db92025",
+            "uuid": "7005c937-8114-4af4-b19c-18143db92025"
+        },
+        {
+            "file": {},
+            "content": [10,9,8,7,6,5,4,3,2,1],
+            "filename": "logo_mwg.png.png",
+            "filesize": 10130,
+            "id": "V2898513808905600871912527163003030702",
+            "pending": false,
+            "skjemanummer": "I000042",
+            "innsendingsType": "omsorgsovertakelse",
+            "uploaded": true,
+            "url": "https://foreldrepengesoknad-api.intern.dev.nav.no/rest/storage/vedlegg/7005c937-8114-4af4-b19c-18143db92025",
+            "uuid": "7005c937-8114-4af4-b19c-18143db92025"
+        }
+    ]
+}

--- a/src/test/resources/json/foreldrepenger_far_gardering_frilans_duplisert_vedlegg.json
+++ b/src/test/resources/json/foreldrepenger_far_gardering_frilans_duplisert_vedlegg.json
@@ -1,0 +1,134 @@
+{
+    "annenForelder": {
+        "erInformertOmSøknaden": true,
+        "fornavn": "LUR",
+        "etternavn": "BAMSE",
+        "fnr": "11111122222",
+        "harRettPåForeldrepenger": true,
+        "kanIkkeOppgis": false
+    },
+    "barn": {
+        "antallBarn": 1,
+        "erBarnetFødt": true,
+        "fødselsdatoer": [
+            "2021-12-05T00:00:00.000Z"
+        ],
+        "termindato": "2021-12-07T00:00:00.000Z"
+    },
+    "dekningsgrad": "100",
+    "erEndringssøknad": false,
+    "harGodkjentOppsummering": true,
+    "harGodkjentVilkår": true,
+    "informasjonOmUtenlandsopphold": {
+        "iNorgeNeste12Mnd": true,
+        "iNorgeSiste12Mnd": true,
+        "senereOpphold": [],
+        "tidligereOpphold": []
+    },
+    "situasjon": "fødsel",
+    "søker": {
+        "erAleneOmOmsorg": false,
+        "frilansInformasjon": {
+            "driverFosterhjem": false,
+            "harJobbetForNærVennEllerFamilieSiste10Mnd": false,
+            "jobberFremdelesSomFrilans": true,
+            "oppdragForNæreVennerEllerFamilieSiste10Mnd": [
+                {
+                    "navnPåArbeidsgiver": "frilanser AS",
+                    "tidsperiode": {
+                        "fom": "2021-12-07T00:00:00.000Z"
+                    }
+                }
+            ],
+            "oppstart": "2020-08-01T00:00:00.000Z"
+        },
+        "harHattAnnenInntektSiste10Mnd": false,
+        "harJobbetSomFrilansSiste10Mnd": true,
+        "harJobbetSomSelvstendigNæringsdrivendeSiste10Mnd": false,
+        "rolle": "FAR",
+        "språkkode": "NB"
+    },
+    "type": "foreldrepenger",
+    "uttaksplan": [
+        {
+            "arbeidsformer": [
+                "FRILANS"
+            ],
+            "erArbeidstaker": false,
+            "erFrilanser": true,
+            "erSelvstendig": false,
+            "forelder": "farMedmor",
+            "gradert": true,
+            "id": "03124180-1056-30233-6748-64970527408373",
+            "konto": "FEDREKVOTE",
+            "orgnumre": [],
+            "stillingsprosent": "50.0",
+            "tidsperiode": {
+                "fom": "2022-06-22T00:00:00.000Z",
+                "tom": "2023-01-17T00:00:00.000Z"
+            },
+            "type": "uttak",
+            "ønskerSamtidigUttak": false
+        },
+        {
+            "forelder": "farMedmor",
+            "gradert": false,
+            "id": "99762609-22500-9613-16080-08791215124085",
+            "konto": "FELLESPERIODE",
+            "morsAktivitetIPerioden": "ARBEID",
+            "tidsperiode": {
+                "fom": "2023-01-18T00:00:00.000Z",
+                "tom": "2023-03-14T00:00:00.000Z"
+            },
+            "type": "uttak",
+            "vedlegg": [
+                "V3872008262447517342619654411304222"
+            ],
+            "ønskerSamtidigUttak": false
+        },
+        {
+            "forelder": "farMedmor",
+            "gradert": false,
+            "id": "99762609-22500-9613-16080-08791215124085",
+            "konto": "FELLESPERIODE",
+            "morsAktivitetIPerioden": "ARBEID",
+            "tidsperiode": {
+                "fom": "2023-03-15T00:00:00.000Z",
+                "tom": "2023-04-14T00:00:00.000Z"
+            },
+            "type": "uttak",
+            "vedlegg": [
+                "V3872008262447517342619654411304223"
+            ],
+            "ønskerSamtidigUttak": false
+        }
+    ],
+    "vedlegg": [
+        {
+            "file": {},
+          "content": [10,9,8,7,6,5,4,3,2,1],
+            "filename": "logo_mwg.png.png",
+            "filesize": 10130,
+            "id": "V3872008262447517342619654411304222",
+            "pending": false,
+            "skjemanummer": "I000038",
+            "innsendingsType": "morsaktivitetdokumentasjon",
+            "uploaded": true,
+            "url": "https://foreldrepengesoknad-api.intern.dev.nav.no/rest/storage/vedlegg/d26911e0-e5d7-454b-840b-34e9f17ed46e",
+            "uuid": "d26911e0-e5d7-454b-840b-34e9f17ed46e"
+        },
+        {
+            "file": {},
+          "content": [10,9,8,7,6,5,4,3,2,1],
+            "filename": "logo_mwg.png.png",
+            "filesize": 10130,
+            "id": "V3872008262447517342619654411304222",
+            "pending": false,
+            "skjemanummer": "I000038",
+            "innsendingsType": "morsaktivitetdokumentasjon",
+            "uploaded": true,
+            "url": "https://foreldrepengesoknad-api.intern.dev.nav.no/rest/storage/vedlegg/d26911e0-e5d7-454b-840b-34e9f17ed46e",
+            "uuid": "d26911e0-e5d7-454b-840b-34e9f17ed46e"
+        }
+    ]
+}

--- a/src/test/resources/json/foreldrepenger_far_gardering_frilans_to_vedlegg_samme_type_ulikt_innhold.json
+++ b/src/test/resources/json/foreldrepenger_far_gardering_frilans_to_vedlegg_samme_type_ulikt_innhold.json
@@ -1,0 +1,134 @@
+{
+    "annenForelder": {
+        "erInformertOmSøknaden": true,
+        "fornavn": "LUR",
+        "etternavn": "BAMSE",
+        "fnr": "11111122222",
+        "harRettPåForeldrepenger": true,
+        "kanIkkeOppgis": false
+    },
+    "barn": {
+        "antallBarn": 1,
+        "erBarnetFødt": true,
+        "fødselsdatoer": [
+            "2021-12-05T00:00:00.000Z"
+        ],
+        "termindato": "2021-12-07T00:00:00.000Z"
+    },
+    "dekningsgrad": "100",
+    "erEndringssøknad": false,
+    "harGodkjentOppsummering": true,
+    "harGodkjentVilkår": true,
+    "informasjonOmUtenlandsopphold": {
+        "iNorgeNeste12Mnd": true,
+        "iNorgeSiste12Mnd": true,
+        "senereOpphold": [],
+        "tidligereOpphold": []
+    },
+    "situasjon": "fødsel",
+    "søker": {
+        "erAleneOmOmsorg": false,
+        "frilansInformasjon": {
+            "driverFosterhjem": false,
+            "harJobbetForNærVennEllerFamilieSiste10Mnd": false,
+            "jobberFremdelesSomFrilans": true,
+            "oppdragForNæreVennerEllerFamilieSiste10Mnd": [
+                {
+                    "navnPåArbeidsgiver": "frilanser AS",
+                    "tidsperiode": {
+                        "fom": "2021-12-07T00:00:00.000Z"
+                    }
+                }
+            ],
+            "oppstart": "2020-08-01T00:00:00.000Z"
+        },
+        "harHattAnnenInntektSiste10Mnd": false,
+        "harJobbetSomFrilansSiste10Mnd": true,
+        "harJobbetSomSelvstendigNæringsdrivendeSiste10Mnd": false,
+        "rolle": "FAR",
+        "språkkode": "NB"
+    },
+    "type": "foreldrepenger",
+    "uttaksplan": [
+        {
+            "arbeidsformer": [
+                "FRILANS"
+            ],
+            "erArbeidstaker": false,
+            "erFrilanser": true,
+            "erSelvstendig": false,
+            "forelder": "farMedmor",
+            "gradert": true,
+            "id": "03124180-1056-30233-6748-64970527408373",
+            "konto": "FEDREKVOTE",
+            "orgnumre": [],
+            "stillingsprosent": "50.0",
+            "tidsperiode": {
+                "fom": "2022-06-22T00:00:00.000Z",
+                "tom": "2023-01-17T00:00:00.000Z"
+            },
+            "type": "uttak",
+            "ønskerSamtidigUttak": false
+        },
+        {
+            "forelder": "farMedmor",
+            "gradert": false,
+            "id": "99762609-22500-9613-16080-08791215124085",
+            "konto": "FELLESPERIODE",
+            "morsAktivitetIPerioden": "ARBEID",
+            "tidsperiode": {
+                "fom": "2023-01-18T00:00:00.000Z",
+                "tom": "2023-03-14T00:00:00.000Z"
+            },
+            "type": "uttak",
+            "vedlegg": [
+                "V3872008262447517342619654411304222"
+            ],
+            "ønskerSamtidigUttak": false
+        },
+        {
+            "forelder": "farMedmor",
+            "gradert": false,
+            "id": "99762609-22500-9613-16080-08791215124085",
+            "konto": "FELLESPERIODE",
+            "morsAktivitetIPerioden": "ARBEID",
+            "tidsperiode": {
+                "fom": "2023-03-15T00:00:00.000Z",
+                "tom": "2023-04-14T00:00:00.000Z"
+            },
+            "type": "uttak",
+            "vedlegg": [
+                "V3872008262447517342619654411304223"
+            ],
+            "ønskerSamtidigUttak": false
+        }
+    ],
+    "vedlegg": [
+        {
+            "file": {},
+            "content": [1,2,3,4,5,6,7,8,9],
+            "filename": "logo_mwg.png.png",
+            "filesize": 10130,
+            "id": "V3872008262447517342619654411304222",
+            "pending": false,
+            "skjemanummer": "I000038",
+            "innsendingsType": "morsaktivitetdokumentasjon",
+            "uploaded": true,
+            "url": "https://foreldrepengesoknad-api.intern.dev.nav.no/rest/storage/vedlegg/d26911e0-e5d7-454b-840b-34e9f17ed46e",
+            "uuid": "d26911e0-e5d7-454b-840b-34e9f17ed46e"
+        },
+        {
+            "file": {},
+            "content": [10,9,8,7,6,5,4,3,2,1],
+            "filename": "logo_mwg.png.png",
+            "filesize": 10130,
+            "id": "V3872008262447517342619654411304223",
+            "pending": false,
+            "skjemanummer": "I000038",
+            "innsendingsType": "morsaktivitetdokumentasjon",
+            "uploaded": true,
+            "url": "https://foreldrepengesoknad-api.intern.dev.nav.no/rest/storage/vedlegg/d26911e0-e5d7-454b-840b-34e9f17ed46e",
+            "uuid": "d26911e0-e5d7-454b-840b-34e9f17ed46e"
+        }
+    ]
+}


### PR DESCRIPTION
…dinger.

**Hva er endringen?**
- Sjekker alle vedlegg for duplikater. 
- Hvis vedlegget har identisk innsendingstype, skjemanummer og innhold som ett annet så regnes den som duplikat. 
- Vedlegget fjernes fra vedleggslisten og alle tilhørende vedleggsreferansen oppdateres til matchede vedlegget som allerede eksisterer. 
- Dette gjøres iterativt gjennom hele listen.


**Hvorfor gjøre dette?**
- Vi vil ikke lenger ha dupliserte vedlegg journalført.
- Saksbehandler vil ikke se dupliserte vedlegg lenger
- Sitter som en guard mellom frontend og backend slik at det ikke sendes ned duplikater.
- Vi vil ikke få timeout pga store innsendelser med mange titalls vedlegg

**Hva gjenstår?**
- Borger vil fremdeles ha samme problemer frem til det fikses i frontend (altså at de må legge ved samme vedlegg flere ganger).
