### PR TITLE
Legger til brev at typen FRITEK som VEDTAK i tidslinjen

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsyn/tidslinje/TidslinjeHendelseDto.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsyn/tidslinje/TidslinjeHendelseDto.java
@@ -21,10 +21,6 @@ public record TidslinjeHendelseDto(LocalDateTime opprettet,
         ENDRINGSSØKNAD,
         INNTEKTSMELDING,
         VEDTAK,
-        VEDTAK_FØRSTEGANG,
-        VEDTAK_ENDRING,
-        VEDTAK_TILBAKEKREVING,
-        VENTER_INNTEKTSMELDING,
         UTGÅENDE_INNHENT_OPPLYSNINGER,
         UTGÅENDE_ETTERLYS_INNTEKTSMELDING
     }

--- a/src/main/java/no/nav/foreldrepenger/selvbetjening/innsyn/tidslinje/TidslinjeTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/selvbetjening/innsyn/tidslinje/TidslinjeTjeneste.java
@@ -71,10 +71,11 @@ public class TidslinjeTjeneste {
             case FORELDREPENGER_ANNULLERT, FORELDREPENGER_AVSLAG, SVANGERSKAPSPENGER_OPPHØR, ENGANGSSTØNAD_INNVILGELSE, SVANGERSKAPSPENGER_AVSLAG,
                 FORELDREPENGER_INNVILGELSE, ENGANGSSTØNAD_AVSLAG, FORELDREPENGER_OPPHØR, SVANGERSKAPSPENGER_INNVILGELSE,
                 VEDTAK_POSITIVT_OLD, VEDTAK_AVSLAG_OLD, VEDTAK_FORELDREPENGER_OLD, VEDTAK_AVSLAG_FORELDREPENGER_OLD,
-                VEDTAK_POSITIVT_OLD_MF, VEDTAK_AVSLAG_OLD_MF, VEDTAK_FORELDREPENGER_OLD_MF, VEDTAK_AVSLAG_FORELDREPENGER_OLD_MF->
+                VEDTAK_POSITIVT_OLD_MF, VEDTAK_AVSLAG_OLD_MF, VEDTAK_FORELDREPENGER_OLD_MF, VEDTAK_AVSLAG_FORELDREPENGER_OLD_MF ->
                 Optional.of(TidslinjeHendelseDto.TidslinjeHendelseType.VEDTAK);
             case INNHENTE_OPPLYSNINGER, INNHENTE_OPPLYSNINGER_OLD, INNHENTE_OPPLYSNINGER_OLD_MF -> Optional.of(TidslinjeHendelseDto.TidslinjeHendelseType.UTGÅENDE_INNHENT_OPPLYSNINGER);
             case ETTERLYS_INNTEKTSMELDING, ETTERLYS_INNTEKTSMELDING_OLD, ETTERLYS_INNTEKTSMELDING_OLD_MF -> Optional.of(TidslinjeHendelseDto.TidslinjeHendelseType.UTGÅENDE_ETTERLYS_INNTEKTSMELDING);
+            case FRITEKSTBREV -> Optional.of(TidslinjeHendelseDto.TidslinjeHendelseType.VEDTAK); // TODO: Er riktig nå, men må mappe til riktig brevkode i fpformidling/fpdokgen
             default -> {
                 LOG.info("Ignorerer utgåpende journalpost med brevkode: {}", enkelJournalpost);
                 yield Optional.empty();

--- a/src/test/java/no/nav/foreldrepenger/selvbetjening/innsyn/tidslinje/TidslinjeTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/selvbetjening/innsyn/tidslinje/TidslinjeTjenesteTest.java
@@ -76,6 +76,23 @@ public class TidslinjeTjenesteTest {
     }
 
     @Test
+    void søknadMedFritekstVedtak() {
+        var saksnummer = DUMMY_SAKSNUMMER;
+        var utgåendeVedtakFritekts = utgåendeVedtakFritekts(saksnummer, LocalDateTime.now());
+        when(safselvbetjeningTjeneste.alle(DUMMY_FNR, saksnummer)).thenReturn(
+            List.of(utgåendeVedtakFritekts));
+
+        var tidslinje = tjeneste.tidslinje(DUMMY_FNR, saksnummer);
+
+        assertThat(tidslinje)
+            .hasSize(1)
+            .extracting(TidslinjeHendelseDto::tidslinjeHendelseType)
+            .containsExactly(
+                TidslinjeHendelseDto.TidslinjeHendelseType.VEDTAK
+            );
+    }
+
+    @Test
     void søknadIMEttersendingVedtakEndringssøknadOgDeretterNyttVedtak() {
         var saksnummer = DUMMY_SAKSNUMMER;
         var tidspunkt = LocalDateTime.now();
@@ -230,6 +247,19 @@ public class TidslinjeTjenesteTest {
         );
     }
 
+    public static EnkelJournalpost utgåendeVedtakFritekts(Saksnummer saksnummer, LocalDateTime mottatt) {
+        return new EnkelJournalpost(
+            "Innvilgelsesbrev foreldrepenger",
+            "5",
+            saksnummer.value(),
+            EnkelJournalpost.DokumentType.UTGÅENDE_DOKUMENT, mottatt,
+            null,
+            List.of(
+                new EnkelJournalpost.Dokument("1", null, EnkelJournalpost.Brevkode.FRITEKSTBREV)
+            )
+        );
+    }
+
 
     public static EnkelJournalpost utgåendeVedtak(Saksnummer saksnummer, LocalDateTime mottatt) {
         return new EnkelJournalpost(
@@ -237,7 +267,7 @@ public class TidslinjeTjenesteTest {
             "5",
             saksnummer.value(),
             EnkelJournalpost.DokumentType.UTGÅENDE_DOKUMENT, mottatt,
-            null, // Todo: Dokumentet har vel ikke en hovedtype her? Elller?
+            null,
             List.of(
                 new EnkelJournalpost.Dokument("1", null, EnkelJournalpost.Brevkode.FORELDREPENGER_INNVILGELSE)
             )
@@ -251,7 +281,7 @@ public class TidslinjeTjenesteTest {
             "5",
             saksnummer.value(),
             EnkelJournalpost.DokumentType.UTGÅENDE_DOKUMENT, tidspunkt,
-            null, // Todo: Dokumentet har vel ikke en hovedtype her? Elller?
+            null,
             List.of(
                 new EnkelJournalpost.Dokument("1", null, EnkelJournalpost.Brevkode.INNHENTE_OPPLYSNINGER)
             )
@@ -266,7 +296,7 @@ public class TidslinjeTjenesteTest {
             saksnummer.value(),
             EnkelJournalpost.DokumentType.UTGÅENDE_DOKUMENT,
             LocalDateTime.now(),
-            null, // Todo: Dokumentet har vel ikke en hovedtype her? Elller?
+            null,
             List.of(
                 new EnkelJournalpost.Dokument("1", null, EnkelJournalpost.Brevkode.ETTERLYS_INNTEKTSMELDING)
             )


### PR DESCRIPTION
Nå vises ingen vedtak i tidslinjen som er av typen fritekst (FRITEK i brevkoden). 
- Skal vi mappe samtlige slike til vedtak?
- Hva om FRITEK blir brukt til andre fritekstbrev i fremtiden?
