### PR TITLE
Localized feilmeldingsfelt også ved 0-størrelse på opplastet vedlegg

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/selvbetjening/mellomlagring/AttachmentEmptyException.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/selvbetjening/mellomlagring/AttachmentEmptyException.java
@@ -1,0 +1,16 @@
+package no.nav.foreldrepenger.selvbetjening.mellomlagring;
+
+import no.nav.foreldrepenger.selvbetjening.vedlegg.AttachmentException;
+
+import org.springframework.context.MessageSource;
+
+public class AttachmentEmptyException extends AttachmentException {
+    protected AttachmentEmptyException(String msg) {
+        super(msg);
+    }
+
+    @Override
+    public String getUserfacingErrorMessage(MessageSource messageSource) {
+        return getMessage(messageSource, "vedlegg.tomtvedlegg");
+    }
+}

--- a/domene/src/main/java/no/nav/foreldrepenger/selvbetjening/mellomlagring/MellomlagringController.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/selvbetjening/mellomlagring/MellomlagringController.java
@@ -2,7 +2,6 @@ package no.nav.foreldrepenger.selvbetjening.mellomlagring;
 
 import static no.nav.foreldrepenger.common.domain.validation.InputValideringRegex.FRITEKST;
 import static no.nav.foreldrepenger.selvbetjening.vedlegg.DelegerendeVedleggSjekker.DELEGERENDE;
-import static org.springframework.http.HttpStatus.NOT_ACCEPTABLE;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.multipart.MultipartFile;
 
 import jakarta.validation.Valid;
@@ -104,7 +102,7 @@ public class MellomlagringController {
     private static byte[] getBytesNullSjekk(MultipartFile file) {
         var bytes = getBytesFraMultipart(file);
         if (bytes.length == 0) {
-            throw new HttpServerErrorException(NOT_ACCEPTABLE, "Kan ikke mellomlagre vedlegg som ikke har innhold");
+            throw new AttachmentEmptyException("Kan ikke mellomlagre vedlegg som ikke har innhold");
         }
         return bytes;
     }

--- a/domene/src/main/resources/visningsvennlig-feilmelding_en.properties
+++ b/domene/src/main/resources/visningsvennlig-feilmelding_en.properties
@@ -5,3 +5,4 @@ vedlegg.for.stort=Attachment size is {0} MB, but cannot exceed {1} MB.
 vedlegg.samlet.for.stort=The total file size of all attachments is {0} MB, but must be less than {1} MB.
 vedlegg.korrumpert=The attachment cannot be opened. Try with a different attachment.
 vedlegg.virus=The attachment is rejected as it contains a computer virus.
+vedlegg.tomtvedlegg=The attachment is empty and cannot be accepted. Try with a different attachment.

--- a/domene/src/main/resources/visningsvennlig-feilmelding_nb.properties
+++ b/domene/src/main/resources/visningsvennlig-feilmelding_nb.properties
@@ -5,3 +5,4 @@ vedlegg.for.stort=Størrelsen på vedlegget er {0} MB. Vi kan ikke motta vedlegg
 vedlegg.samlet.for.stort=Den totale størrelsen på alle vedlegg er {0} MB. Vi kan ikke motta en vedleggsforsendelse større enn {1} MB.
 vedlegg.korrumpert=Vedlegget kan ikke åpnes. Forsøk med et annet vedlegg.
 vedlegg.virus=Vi har oppdaget et datavirus i vedlegget du har forsøkt laste opp. Vedlegget er derfor avvist.
+vedlegg.tomtvedlegg=Vedlegget er tomt. Vennligst forsøk med et nytt vedlegg.

--- a/domene/src/main/resources/visningsvennlig-feilmelding_nn.properties
+++ b/domene/src/main/resources/visningsvennlig-feilmelding_nn.properties
@@ -5,3 +5,4 @@ vedlegg.for.stort=Storleiken på vedlegget er {0} MB. Vi kan ikkje motta vedlegg
 vedlegg.samlet.for.stort=Den totale storleiken på alle vedlegg er {0} MB. Vi kan ikkje motta ein vedleggsforsending større enn {1} MB.
 vedlegg.korrumpert=Vedlegget kan ikkje opnast. Forsøk med eit anna vedlegg.
 vedlegg.virus=Vi har oppdaga eit datavirus i vedlegget du har forsøkt laste opp. Vedlegget er difor avvist.
+vedlegg.tomtvedlegg=Vedlegget er tomt. Vennlegst prøv med eit nytt vedlegg.


### PR DESCRIPTION
En praktisk konsekvens er at denne feilen går fra 406 NOT_ACCEPTABLE til 422 som øvrige attachment-exceptions