### PR TITLE
Differensiert timeout config mellom innsending og oppslag

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/InnsendingConnection.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/selvbetjening/innsending/InnsendingConnection.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.selvbetjening.innsending;
 import static no.nav.boot.conditionals.EnvUtil.isGcp;
 import static no.nav.foreldrepenger.common.domain.felles.InnsendingsType.LASTET_OPP;
 import static no.nav.foreldrepenger.common.util.StreamUtil.safeStream;
+import static no.nav.foreldrepenger.selvbetjening.http.RestClientConfiguration.LONG_TIMEOUT;
 import static no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.mapper.EttersendingMapper.tilEttersending;
 import static no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.mapper.SøknadMapper.tilSøknad;
 import static no.nav.foreldrepenger.selvbetjening.vedlegg.VedleggUtil.mediaType;
@@ -13,6 +14,7 @@ import static org.springframework.http.MediaType.MULTIPART_MIXED;
 import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -43,7 +45,10 @@ public class InnsendingConnection extends AbstractRestConnection {
     private final Environment env;
     private final InnsendingConfig config;
 
-    public InnsendingConnection(RestOperations operations, ObjectMapper mapper, Environment env, InnsendingConfig config) {
+    public InnsendingConnection(@Qualifier(LONG_TIMEOUT) RestOperations operations,
+                                ObjectMapper mapper,
+                                Environment env,
+                                InnsendingConfig config) {
         super(operations);
         this.mapper = mapper;
         this.env = env;


### PR DESCRIPTION
Legger ved mvc metrikker siste 6 timer (NB: justerer resttemplate ikke inngående verdier.. mellomlagring bruker egen klient i sdk). "hent-dokument" er kanskje kandidat til å ta lang tid om dokument er stort?

![image](https://github.com/navikt/foreldrepengesoknad-api/assets/1026850/2ce9088a-9f73-414c-8103-7aff87dbd88c)

Siste uka:
max hent-dokument på 5.5s med avg 129ms
max sokerinfo 7.7s med avg 590ms (dette er vel flere kall, så slik sett flere sekvensielle timeouts)