### PR TITLE
Tfp 5815 ferieperioder svp

### DIFF
--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/dto/svangerskapspenger/AvtaltFerie.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/dto/svangerskapspenger/AvtaltFerie.java
@@ -1,9 +1,0 @@
-package no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.svangerskapspenger;
-
-import jakarta.validation.Valid;
-import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.svangerskapspenger.arbeidsforhold.ArbeidsforholdDto;
-
-import java.time.LocalDate;
-
-public record AvtaltFerie(@Valid ArbeidsforholdDto arbeidsforholdDto, LocalDate fom, LocalDate tom) {
-}

--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/dto/svangerskapspenger/AvtaltFerie.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/dto/svangerskapspenger/AvtaltFerie.java
@@ -1,0 +1,9 @@
+package no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.svangerskapspenger;
+
+import jakarta.validation.Valid;
+import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.svangerskapspenger.arbeidsforhold.ArbeidsforholdDto;
+
+import java.time.LocalDate;
+
+public record AvtaltFerie(@Valid ArbeidsforholdDto arbeidsforholdDto, LocalDate fom, LocalDate tom) {
+}

--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/dto/svangerskapspenger/SvangerskapspengesøknadDto.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/dto/svangerskapspenger/SvangerskapspengesøknadDto.java
@@ -18,6 +18,7 @@ import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.validering.Ve
 @Deprecated
 public record SvangerskapspengesøknadDto(LocalDate mottattdato,
                                          @Valid @NotNull @Size(max = 100) List<@Valid TilretteleggingDto> tilrettelegging,
+                                         @Valid @Size(max = 100) List<@Valid AvtaltFerie> avtaltFerie,
                                          @Valid @NotNull BarnDto barn,
                                          @Valid @NotNull UtenlandsoppholdDto informasjonOmUtenlandsopphold,
                                          @Valid @NotNull SøkerDto søker,

--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/dto/svangerskapspenger/SvangerskapspengesøknadDto.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/dto/svangerskapspenger/SvangerskapspengesøknadDto.java
@@ -28,6 +28,7 @@ public record SvangerskapspengesøknadDto(LocalDate mottattdato,
     public SvangerskapspengesøknadDto {
         tilrettelegging = Optional.ofNullable(tilrettelegging).orElse(List.of());
         vedlegg = Optional.ofNullable(vedlegg).orElse(List.of());
+        avtaltFerie = Optional.ofNullable(avtaltFerie).orElse(List.of());
     }
 
     @Override

--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/dto/svangerskapspenger/SvangerskapspengesøknadDto.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/dto/svangerskapspenger/SvangerskapspengesøknadDto.java
@@ -14,11 +14,12 @@ import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.Utenlandsopph
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.VedleggDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.foreldrepenger.Situasjon;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.validering.VedlegglistestørrelseConstraint;
+import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.svangerskapspenger.AvtaltFerieDto;
 
 @Deprecated
 public record SvangerskapspengesøknadDto(LocalDate mottattdato,
                                          @Valid @NotNull @Size(max = 100) List<@Valid TilretteleggingDto> tilrettelegging,
-                                         @Valid @Size(max = 100) List<@Valid AvtaltFerie> avtaltFerie,
+                                         @Valid @Size(max = 100) List<@Valid AvtaltFerieDto> avtaltFerie,
                                          @Valid @NotNull BarnDto barn,
                                          @Valid @NotNull UtenlandsoppholdDto informasjonOmUtenlandsopphold,
                                          @Valid @NotNull SøkerDto søker,

--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/mapper/SvangerskapspengerMapper.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/mapper/SvangerskapspengerMapper.java
@@ -74,7 +74,7 @@ public final class SvangerskapspengerMapper {
 
     private static List<AvtaltFerie> tilFerieperioder(SvangerskapspengesøknadDto s) {
         return safeStream(s.avtaltFerie()).map(af -> {
-            var arbeidsforhold = tilArbeidsforhold(af.arbeidsforholdDto());
+            var arbeidsforhold = tilArbeidsforhold(af.arbeidsforhold());
             return new AvtaltFerie(arbeidsforhold, af.fom(), af.tom());
         }).toList();
     }

--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/mapper/SvangerskapspengerMapper.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/mapper/SvangerskapspengerMapper.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.mapper;
 
+import static no.nav.foreldrepenger.common.util.StreamUtil.safeStream;
 import static no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.mapper.CommonMapper.tilOppholdIUtlandet;
 import static no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.mapper.CommonMapper.tilOpptjening;
 import static no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.mapper.CommonMapper.tilVedlegg;
@@ -12,6 +13,7 @@ import no.nav.foreldrepenger.common.domain.BrukerRolle;
 import no.nav.foreldrepenger.common.domain.Søker;
 import no.nav.foreldrepenger.common.domain.Søknad;
 import no.nav.foreldrepenger.common.domain.felles.ProsentAndel;
+import no.nav.foreldrepenger.common.domain.svangerskapspenger.AvtaltFerie;
 import no.nav.foreldrepenger.common.domain.svangerskapspenger.Svangerskapspenger;
 import no.nav.foreldrepenger.common.domain.svangerskapspenger.tilrettelegging.DelvisTilrettelegging;
 import no.nav.foreldrepenger.common.domain.svangerskapspenger.tilrettelegging.HelTilrettelegging;
@@ -65,8 +67,16 @@ public final class SvangerskapspengerMapper {
             tilFødselsdato(s),
             tilOppholdIUtlandet(s),
             tilOpptjening(s.søker(), vedlegg),
-            tilTilrettelegging(s, vedlegg)
+            tilTilrettelegging(s, vedlegg),
+            tilFerieperioder(s)
         );
+    }
+
+    private static List<AvtaltFerie> tilFerieperioder(SvangerskapspengesøknadDto s) {
+        return safeStream(s.avtaltFerie()).map(af -> {
+            var arbeidsforhold = tilArbeidsforhold(af.arbeidsforholdDto());
+            return new AvtaltFerie(arbeidsforhold, af.fom(), af.tom());
+        }).toList();
     }
 
     private static LocalDate tilFødselsdato(SvangerskapspengesøknadDto s) {

--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/dto/svangerskapspenger/AvtaltFerieDto.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/dto/svangerskapspenger/AvtaltFerieDto.java
@@ -1,0 +1,9 @@
+package no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.svangerskapspenger;
+
+import jakarta.validation.Valid;
+import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.svangerskapspenger.arbeidsforhold.ArbeidsforholdDto;
+
+import java.time.LocalDate;
+
+public record AvtaltFerieDto(@Valid ArbeidsforholdDto arbeidsforholdDto, LocalDate fom, LocalDate tom) {
+}

--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/dto/svangerskapspenger/AvtaltFerieDto.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/dto/svangerskapspenger/AvtaltFerieDto.java
@@ -5,5 +5,5 @@ import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.svangerska
 
 import java.time.LocalDate;
 
-public record AvtaltFerieDto(@Valid ArbeidsforholdDto arbeidsforholdDto, LocalDate fom, LocalDate tom) {
+public record AvtaltFerieDto(@Valid ArbeidsforholdDto arbeidsforhold, LocalDate fom, LocalDate tom) {
 }

--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/dto/svangerskapspenger/SvangerskapspengesøknadDto.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/dto/svangerskapspenger/SvangerskapspengesøknadDto.java
@@ -25,7 +25,7 @@ public record SvangerskapspengesøknadDto(LocalDate mottattdato,
                                          @Valid @Size(max = 15) List<@Valid @NotNull AnnenInntektDto> andreInntekterSiste10Mnd,
                                          @Valid @Size(max = 40) List<@Valid @NotNull UtenlandsoppholdsperiodeDto> utenlandsopphold,
                                          @Valid @NotNull @Size(max = 100) List<@Valid @NotNull TilretteleggingDto> tilretteleggingsbehov,
-                                         @Valid @Size(max = 100) List<@Valid @NotNull AvtaltFerieDto> avtalteFerieperioder,
+                                         @Valid @Size(max = 100) List<@Valid @NotNull AvtaltFerieDto> avtaltFerie,
                                          @Valid @VedlegglistestørrelseConstraint @Size(max = 100) List<@Valid  @NotNull VedleggDto> vedlegg) implements SøknadDto {
 
     public SvangerskapspengesøknadDto {
@@ -34,6 +34,6 @@ public record SvangerskapspengesøknadDto(LocalDate mottattdato,
         utenlandsopphold = Optional.ofNullable(utenlandsopphold).orElse(List.of());
         tilretteleggingsbehov = Optional.ofNullable(tilretteleggingsbehov).orElse(List.of());
         vedlegg = Optional.ofNullable(vedlegg).orElse(List.of());
-        avtalteFerieperioder = Optional.ofNullable(avtalteFerieperioder).orElse(List.of());
+        avtaltFerie = Optional.ofNullable(avtaltFerie).orElse(List.of());
     }
 }

--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/dto/svangerskapspenger/SvangerskapspengesøknadDto.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/dto/svangerskapspenger/SvangerskapspengesøknadDto.java
@@ -12,7 +12,6 @@ import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.AnnenInntektD
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.FrilansInformasjonDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.NæringDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.VedleggDto;
-import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.svangerskapspenger.AvtaltFerie;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.validering.VedlegglistestørrelseConstraint;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.BarnDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.SøknadDto;
@@ -26,7 +25,7 @@ public record SvangerskapspengesøknadDto(LocalDate mottattdato,
                                          @Valid @Size(max = 15) List<@Valid @NotNull AnnenInntektDto> andreInntekterSiste10Mnd,
                                          @Valid @Size(max = 40) List<@Valid @NotNull UtenlandsoppholdsperiodeDto> utenlandsopphold,
                                          @Valid @NotNull @Size(max = 100) List<@Valid @NotNull TilretteleggingDto> tilretteleggingsbehov,
-                                         @Valid @Size(max = 100) List<@Valid @NotNull AvtaltFerie> avtalteFerieperioder,
+                                         @Valid @Size(max = 100) List<@Valid @NotNull AvtaltFerieDto> avtalteFerieperioder,
                                          @Valid @VedlegglistestørrelseConstraint @Size(max = 100) List<@Valid  @NotNull VedleggDto> vedlegg) implements SøknadDto {
 
     public SvangerskapspengesøknadDto {

--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/dto/svangerskapspenger/SvangerskapspengesøknadDto.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/dto/svangerskapspenger/SvangerskapspengesøknadDto.java
@@ -12,6 +12,7 @@ import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.AnnenInntektD
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.FrilansInformasjonDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.NæringDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.VedleggDto;
+import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.svangerskapspenger.AvtaltFerie;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.validering.VedlegglistestørrelseConstraint;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.BarnDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.SøknadDto;
@@ -25,6 +26,7 @@ public record SvangerskapspengesøknadDto(LocalDate mottattdato,
                                          @Valid @Size(max = 15) List<@Valid @NotNull AnnenInntektDto> andreInntekterSiste10Mnd,
                                          @Valid @Size(max = 40) List<@Valid @NotNull UtenlandsoppholdsperiodeDto> utenlandsopphold,
                                          @Valid @NotNull @Size(max = 100) List<@Valid @NotNull TilretteleggingDto> tilretteleggingsbehov,
+                                         @Valid @Size(max = 100) List<@Valid AvtaltFerie> avtalteFerieperioder,
                                          @Valid @VedlegglistestørrelseConstraint @Size(max = 100) List<@Valid  @NotNull VedleggDto> vedlegg) implements SøknadDto {
 
     public SvangerskapspengesøknadDto {
@@ -33,5 +35,6 @@ public record SvangerskapspengesøknadDto(LocalDate mottattdato,
         utenlandsopphold = Optional.ofNullable(utenlandsopphold).orElse(List.of());
         tilretteleggingsbehov = Optional.ofNullable(tilretteleggingsbehov).orElse(List.of());
         vedlegg = Optional.ofNullable(vedlegg).orElse(List.of());
+        avtalteFerieperioder = Optional.ofNullable(avtalteFerieperioder).orElse(List.of());
     }
 }

--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/dto/svangerskapspenger/SvangerskapspengesøknadDto.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/dto/svangerskapspenger/SvangerskapspengesøknadDto.java
@@ -26,7 +26,7 @@ public record SvangerskapspengesøknadDto(LocalDate mottattdato,
                                          @Valid @Size(max = 15) List<@Valid @NotNull AnnenInntektDto> andreInntekterSiste10Mnd,
                                          @Valid @Size(max = 40) List<@Valid @NotNull UtenlandsoppholdsperiodeDto> utenlandsopphold,
                                          @Valid @NotNull @Size(max = 100) List<@Valid @NotNull TilretteleggingDto> tilretteleggingsbehov,
-                                         @Valid @Size(max = 100) List<@Valid AvtaltFerie> avtalteFerieperioder,
+                                         @Valid @Size(max = 100) List<@Valid @NotNull AvtaltFerie> avtalteFerieperioder,
                                          @Valid @VedlegglistestørrelseConstraint @Size(max = 100) List<@Valid  @NotNull VedleggDto> vedlegg) implements SøknadDto {
 
     public SvangerskapspengesøknadDto {

--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/mapper/SvangerskapspengerMapper.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/mapper/SvangerskapspengerMapper.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.mapper;
 
+import static no.nav.foreldrepenger.common.util.StreamUtil.safeStream;
 import static no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.mapper.CommonMapper.tilAnnenOpptjening;
 import static no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.mapper.CommonMapper.tilEgenNæring;
 import static no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.mapper.CommonMapper.tilFrilans;
@@ -17,6 +18,7 @@ import no.nav.foreldrepenger.common.domain.Søker;
 import no.nav.foreldrepenger.common.domain.Søknad;
 import no.nav.foreldrepenger.common.domain.felles.ProsentAndel;
 import no.nav.foreldrepenger.common.domain.felles.opptjening.Opptjening;
+import no.nav.foreldrepenger.common.domain.svangerskapspenger.AvtaltFerie;
 import no.nav.foreldrepenger.common.domain.svangerskapspenger.Svangerskapspenger;
 import no.nav.foreldrepenger.common.domain.svangerskapspenger.tilrettelegging.DelvisTilrettelegging;
 import no.nav.foreldrepenger.common.domain.svangerskapspenger.tilrettelegging.HelTilrettelegging;
@@ -62,10 +64,18 @@ public final class SvangerskapspengerMapper {
             tilFødselsdato(s.barn()),
             tilOppholdIUtlandet(s),
             tilOpptjening(s, vedlegg),
-            tilTilrettelegging(s, vedlegg)
+            tilTilrettelegging(s, vedlegg),
+            tilFerieperioder(s)
         );
     }
 
+
+    private static List<AvtaltFerie> tilFerieperioder(SvangerskapspengesøknadDto s) {
+        return safeStream(s.avtalteFerieperioder()).map(af -> {
+            var arbeidsforhold = tilArbeidsforhold(af.arbeidsforholdDto());
+            return new AvtaltFerie(arbeidsforhold, af.fom(), af.tom());
+        }).toList();
+    }
     private static LocalDate tilTermindato(BarnDto barn) {
         if (barn instanceof FødselDto fødsel) {
             return fødsel.termindato();

--- a/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/mapper/SvangerskapspengerMapper.java
+++ b/kontrakt/src/main/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/mapper/SvangerskapspengerMapper.java
@@ -71,8 +71,8 @@ public final class SvangerskapspengerMapper {
 
 
     private static List<AvtaltFerie> tilFerieperioder(SvangerskapspengesøknadDto s) {
-        return safeStream(s.avtalteFerieperioder()).map(af -> {
-            var arbeidsforhold = tilArbeidsforhold(af.arbeidsforholdDto());
+        return safeStream(s.avtaltFerie()).map(af -> {
+            var arbeidsforhold = tilArbeidsforhold(af.arbeidsforhold());
             return new AvtaltFerie(arbeidsforhold, af.fom(), af.tom());
         }).toList();
     }

--- a/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/mapper/EndringssøknadFPMappingKonsistensTest.java
+++ b/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/mapper/EndringssøknadFPMappingKonsistensTest.java
@@ -29,7 +29,7 @@ import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.util.builder.Barn
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.util.builder.EndringssøknadBuilder;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.util.builder.SøkerBuilder;
 
-class EndrignssøknadFPMappingKonsistensTest {
+class EndringssøknadFPMappingKonsistensTest {
     private static final LocalDate NOW = LocalDate.now();
     private static final Fødselsnummer DUMMY_FNR = new Fødselsnummer("0000000000");
 

--- a/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/mapper/SvangerskapspengerMappingKonsistensTest.java
+++ b/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/mapper/SvangerskapspengerMappingKonsistensTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDate;
 import java.util.List;
 
-import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.svangerskapspenger.AvtaltFerie;
+import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.svangerskapspenger.AvtaltFerieDto;
 
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +43,7 @@ class SvangerskapspengerMappingKonsistensTest {
             delvis(NOW, NOW, ArbeidsforholdMaler.privatArbeidsgiver(DUMMY_FNR), 55.0).build(),
             ingen(NOW.plusWeeks(1), NOW.plusWeeks(1), ArbeidsforholdMaler.virksomhet(Orgnummer.MAGIC_ORG)).build()
         );
-        var ferie = new AvtaltFerie(ArbeidsforholdMaler.virksomhet(Orgnummer.MAGIC_ORG), LocalDate.now().plusDays(10),
+        var ferie = new AvtaltFerieDto(ArbeidsforholdMaler.virksomhet(Orgnummer.MAGIC_ORG), LocalDate.now().plusDays(10),
             LocalDate.now().plusDays(20));
         var søknadDto = new SvangerskapspengerBuilder(tilretteleggingerDto)
             .medMedlemsskap(medlemskapUtlandetForrige12mnd())
@@ -64,9 +64,10 @@ class SvangerskapspengerMappingKonsistensTest {
         assertThat(mappedSøknad.getMottattdato()).isEqualTo(søknadDto.mottattdato());
         assertThat(mappedSøknad.getTilleggsopplysninger()).isNull();
 
-        var ytelse = mappedSøknad.getYtelse();
-        assertThat(ytelse).isInstanceOf(Svangerskapspenger.class);
-        var tilrettelegginger = ((Svangerskapspenger) ytelse).tilrettelegging();
+
+        assertThat(mappedSøknad.getYtelse()).isInstanceOf(Svangerskapspenger.class);
+        var svpMappet = (Svangerskapspenger) mappedSøknad.getYtelse();
+        var tilrettelegginger = svpMappet.tilrettelegging();
         assertThat(tilrettelegginger).hasSameSizeAs(tilretteleggingerDto)
             .hasExactlyElementsOfTypes(
                 HelTilrettelegging.class,
@@ -86,6 +87,12 @@ class SvangerskapspengerMappingKonsistensTest {
                 PrivatArbeidsgiver.class,
                 Virksomhet.class
             );
+        assertThat(svpMappet.avtaltFerie()).hasSize(1)
+            .first().satisfies(af -> {
+                assertThat(af.arbeidsforhold()).isInstanceOf(Virksomhet.class);
+                assertThat(af.ferieFom()).isEqualTo(LocalDate.now().plusDays(10));
+                assertThat(af.ferieTom()).isEqualTo(LocalDate.now().plusDays(20));
+            });
 
     }
 

--- a/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/mapper/SvangerskapspengerMappingKonsistensTest.java
+++ b/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/mapper/SvangerskapspengerMappingKonsistensTest.java
@@ -52,7 +52,7 @@ class SvangerskapspengerMappingKonsistensTest {
                 .medSelvstendigNæringsdrivendeInformasjon(List.of(OpptjeningMaler.egenNaeringOpptjening(Orgnummer.MAGIC_ORG.value())))
                 .build())
             .medBarn(BarnBuilder.termin(2, LocalDate.now().plusWeeks(2)).build())
-            .medAvtaltFerie(ferie)
+            .medAvtaltFerie(List.of(ferie))
             .build();
 
         // Act

--- a/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/mapper/SvangerskapspengerMappingKonsistensTest.java
+++ b/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/mapper/SvangerskapspengerMappingKonsistensTest.java
@@ -9,6 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDate;
 import java.util.List;
 
+import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.svangerskapspenger.AvtaltFerie;
+
 import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.common.domain.BrukerRolle;
@@ -41,6 +43,8 @@ class SvangerskapspengerMappingKonsistensTest {
             delvis(NOW, NOW, ArbeidsforholdMaler.privatArbeidsgiver(DUMMY_FNR), 55.0).build(),
             ingen(NOW.plusWeeks(1), NOW.plusWeeks(1), ArbeidsforholdMaler.virksomhet(Orgnummer.MAGIC_ORG)).build()
         );
+        var ferie = new AvtaltFerie(ArbeidsforholdMaler.virksomhet(Orgnummer.MAGIC_ORG), LocalDate.now().plusDays(10),
+            LocalDate.now().plusDays(20));
         var søknadDto = new SvangerskapspengerBuilder(tilretteleggingerDto)
             .medMedlemsskap(medlemskapUtlandetForrige12mnd())
             .medSøker(new SøkerBuilder(BrukerRolle.MOR)
@@ -48,6 +52,7 @@ class SvangerskapspengerMappingKonsistensTest {
                 .medSelvstendigNæringsdrivendeInformasjon(List.of(OpptjeningMaler.egenNaeringOpptjening(Orgnummer.MAGIC_ORG.value())))
                 .build())
             .medBarn(BarnBuilder.termin(2, LocalDate.now().plusWeeks(2)).build())
+            .medAvtaltFerie(ferie)
             .build();
 
         // Act

--- a/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/util/builder/SvangerskapspengerBuilder.java
+++ b/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/util/builder/SvangerskapspengerBuilder.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.util.builder;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.BarnDto;

--- a/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/util/builder/SvangerskapspengerBuilder.java
+++ b/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/util/builder/SvangerskapspengerBuilder.java
@@ -16,7 +16,7 @@ public class SvangerskapspengerBuilder {
     private LocalDate mottattdato;
     private List<TilretteleggingDto> tilrettelegging;
 
-    private List<AvtaltFerieDto> avtaltFerie = new ArrayList<>();
+    private List<AvtaltFerieDto> avtaltFerie;
     private BarnDto barn;
     private UtenlandsoppholdDto informasjonOmUtenlandsopphold;
     private SøkerDto søker;
@@ -57,8 +57,8 @@ public class SvangerskapspengerBuilder {
         return this;
     }
 
-    public SvangerskapspengerBuilder medAvtaltFerie(AvtaltFerieDto avtaltFerie) {
-        this.avtaltFerie.add(avtaltFerie);
+    public SvangerskapspengerBuilder medAvtaltFerie(List<AvtaltFerieDto> avtaltFerie) {
+        this.avtaltFerie = avtaltFerie;
         return this;
     }
 

--- a/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/util/builder/SvangerskapspengerBuilder.java
+++ b/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/util/builder/SvangerskapspengerBuilder.java
@@ -1,18 +1,22 @@
 package no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.util.builder;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.BarnDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.SøkerDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.UtenlandsoppholdDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.VedleggDto;
+import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.svangerskapspenger.AvtaltFerie;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.svangerskapspenger.SvangerskapspengesøknadDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.svangerskapspenger.TilretteleggingDto;
 
 public class SvangerskapspengerBuilder {
     private LocalDate mottattdato;
     private List<TilretteleggingDto> tilrettelegging;
+
+    private List<AvtaltFerie> avtaltFerie = new ArrayList<>();
     private BarnDto barn;
     private UtenlandsoppholdDto informasjonOmUtenlandsopphold;
     private SøkerDto søker;
@@ -53,11 +57,17 @@ public class SvangerskapspengerBuilder {
         return this;
     }
 
+    public SvangerskapspengerBuilder medAvtaltFerie(AvtaltFerie avtaltFerie) {
+        this.avtaltFerie.add(avtaltFerie);
+        return this;
+    }
+
     public SvangerskapspengesøknadDto build() {
         if (mottattdato == null) mottattdato = LocalDate.now();
         return new SvangerskapspengesøknadDto(
                 mottattdato,
                 tilrettelegging,
+                avtaltFerie,
                 barn,
                 informasjonOmUtenlandsopphold,
                 søker,

--- a/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/util/builder/SvangerskapspengerBuilder.java
+++ b/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/util/builder/SvangerskapspengerBuilder.java
@@ -8,7 +8,7 @@ import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.BarnDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.SøkerDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.UtenlandsoppholdDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.VedleggDto;
-import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.svangerskapspenger.AvtaltFerie;
+import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.svangerskapspenger.AvtaltFerieDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.svangerskapspenger.SvangerskapspengesøknadDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.svangerskapspenger.TilretteleggingDto;
 
@@ -16,7 +16,7 @@ public class SvangerskapspengerBuilder {
     private LocalDate mottattdato;
     private List<TilretteleggingDto> tilrettelegging;
 
-    private List<AvtaltFerie> avtaltFerie = new ArrayList<>();
+    private List<AvtaltFerieDto> avtaltFerie = new ArrayList<>();
     private BarnDto barn;
     private UtenlandsoppholdDto informasjonOmUtenlandsopphold;
     private SøkerDto søker;
@@ -57,7 +57,7 @@ public class SvangerskapspengerBuilder {
         return this;
     }
 
-    public SvangerskapspengerBuilder medAvtaltFerie(AvtaltFerie avtaltFerie) {
+    public SvangerskapspengerBuilder medAvtaltFerie(AvtaltFerieDto avtaltFerie) {
         this.avtaltFerie.add(avtaltFerie);
         return this;
     }

--- a/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/mapper/SvangerskapspengerMappingKonsistensTest.java
+++ b/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/mapper/SvangerskapspengerMappingKonsistensTest.java
@@ -8,6 +8,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDate;
 import java.util.List;
 
+import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.svangerskapspenger.AvtaltFerieDto;
+
 import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.common.domain.BrukerRolle;
@@ -42,9 +44,12 @@ class SvangerskapspengerMappingKonsistensTest {
             delvis(NOW, NOW, ArbeidsforholdMaler.privatArbeidsgiver(DUMMY_FNR), 55.0).build(),
             ingen(NOW.plusWeeks(1), NOW.plusWeeks(1), ArbeidsforholdMaler.virksomhet(Orgnummer.MAGIC_ORG)).build()
         );
+        var ferie = new AvtaltFerieDto(ArbeidsforholdMaler.virksomhet(Orgnummer.MAGIC_ORG), LocalDate.now().plusDays(10),
+            LocalDate.now().plusDays(20));
         var søknadDto = new SvangerskapspengerBuilder(tilretteleggingerDto)
             .medUtenlandsopphold(UtenlandsoppholdMaler.oppholdIUtlandetForrige12mnd())
             .medSpråkkode(Målform.EN)
+            .medAvtaltFerieListe(List.of(ferie))
             .medSelvstendigNæringsdrivendeInformasjon(List.of(OpptjeningMaler.egenNaeringOpptjening(Orgnummer.MAGIC_ORG.value())))
             .medBarn(BarnBuilder.termin(2, LocalDate.now().plusWeeks(2)).build())
             .build();
@@ -58,9 +63,9 @@ class SvangerskapspengerMappingKonsistensTest {
         assertThat(mappedSøknad.getMottattdato()).isEqualTo(søknadDto.mottattdato());
         assertThat(mappedSøknad.getTilleggsopplysninger()).isNull();
 
-        var ytelse = mappedSøknad.getYtelse();
-        assertThat(ytelse).isInstanceOf(Svangerskapspenger.class);
-        var tilrettelegginger = ((Svangerskapspenger) ytelse).tilrettelegging();
+        assertThat(mappedSøknad.getYtelse()).isInstanceOf(Svangerskapspenger.class);
+        var svpMappet = (Svangerskapspenger) mappedSøknad.getYtelse();
+        var tilrettelegginger = svpMappet.tilrettelegging();
         assertThat(tilrettelegginger).hasSameSizeAs(tilretteleggingerDto)
             .hasExactlyElementsOfTypes(
                 HelTilrettelegging.class,
@@ -80,6 +85,12 @@ class SvangerskapspengerMappingKonsistensTest {
                 PrivatArbeidsgiver.class,
                 Virksomhet.class
             );
+        assertThat(svpMappet.avtaltFerie()).hasSize(1)
+            .first().satisfies(af -> {
+                assertThat(af.arbeidsforhold()).isInstanceOf(Virksomhet.class);
+                assertThat(af.ferieFom()).isEqualTo(LocalDate.now().plusDays(10));
+                assertThat(af.ferieTom()).isEqualTo(LocalDate.now().plusDays(20));
+            });
     }
 
     @Test

--- a/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/mapper/SvangerskapspengerMappingKonsistensTest.java
+++ b/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/mapper/SvangerskapspengerMappingKonsistensTest.java
@@ -49,7 +49,7 @@ class SvangerskapspengerMappingKonsistensTest {
         var søknadDto = new SvangerskapspengerBuilder(tilretteleggingerDto)
             .medUtenlandsopphold(UtenlandsoppholdMaler.oppholdIUtlandetForrige12mnd())
             .medSpråkkode(Målform.EN)
-            .medAvtaltFerieListe(List.of(ferie))
+            .medAvtaltFerie(List.of(ferie))
             .medSelvstendigNæringsdrivendeInformasjon(List.of(OpptjeningMaler.egenNaeringOpptjening(Orgnummer.MAGIC_ORG.value())))
             .medBarn(BarnBuilder.termin(2, LocalDate.now().plusWeeks(2)).build())
             .build();

--- a/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/util/builder/SvangerskapspengerBuilder.java
+++ b/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/util/builder/SvangerskapspengerBuilder.java
@@ -23,7 +23,7 @@ public class SvangerskapspengerBuilder {
     List<AnnenInntektDto> andreInntekterSiste10Mnd;
     List<UtenlandsoppholdsperiodeDto> utenlandsopphold;
     List<TilretteleggingDto> tilretteleggingsbehov;
-    List<AvtaltFerieDto> avtalteFerieperioder;
+    List<AvtaltFerieDto> avtaltFerie;
     private List<VedleggDto> vedlegg;
 
     public SvangerskapspengerBuilder(List<TilretteleggingDto> tilretteleggingsbehov) {
@@ -65,8 +65,8 @@ public class SvangerskapspengerBuilder {
         return this;
     }
 
-    public SvangerskapspengerBuilder medAvtaltFerieListe(List<AvtaltFerieDto> avtalteFerieperioder) {
-        this.avtalteFerieperioder = avtalteFerieperioder;
+    public SvangerskapspengerBuilder medAvtaltFerie(List<AvtaltFerieDto> avtaltFerie) {
+        this.avtaltFerie = avtaltFerie;
         return this;
     }
 
@@ -85,8 +85,7 @@ public class SvangerskapspengerBuilder {
             selvstendigNæringsdrivendeInformasjon,
             andreInntekterSiste10Mnd,
             utenlandsopphold,
-            tilretteleggingsbehov,
-            avtalteFerieperioder,
+            tilretteleggingsbehov, avtaltFerie,
             vedlegg
         );
     }

--- a/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/util/builder/SvangerskapspengerBuilder.java
+++ b/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/util/builder/SvangerskapspengerBuilder.java
@@ -65,6 +65,11 @@ public class SvangerskapspengerBuilder {
         return this;
     }
 
+    public SvangerskapspengerBuilder medAvtaltFerieListe(List<AvtaltFerie> utenlandsopphold) {
+        this.avtalteFerieperioder = avtalteFerieperioder;
+        return this;
+    }
+
     public SvangerskapspengerBuilder medVedlegg(List<VedleggDto> vedlegg) {
         this.vedlegg = vedlegg;
         return this;

--- a/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/util/builder/SvangerskapspengerBuilder.java
+++ b/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/util/builder/SvangerskapspengerBuilder.java
@@ -8,7 +8,7 @@ import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.AnnenInntektD
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.FrilansInformasjonDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.NæringDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.VedleggDto;
-import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.svangerskapspenger.AvtaltFerie;
+import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.svangerskapspenger.AvtaltFerieDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.BarnDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.UtenlandsoppholdsperiodeDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.svangerskapspenger.SvangerskapspengesøknadDto;
@@ -23,7 +23,7 @@ public class SvangerskapspengerBuilder {
     List<AnnenInntektDto> andreInntekterSiste10Mnd;
     List<UtenlandsoppholdsperiodeDto> utenlandsopphold;
     List<TilretteleggingDto> tilretteleggingsbehov;
-    List<AvtaltFerie> avtalteFerieperioder;
+    List<AvtaltFerieDto> avtalteFerieperioder;
     private List<VedleggDto> vedlegg;
 
     public SvangerskapspengerBuilder(List<TilretteleggingDto> tilretteleggingsbehov) {
@@ -65,7 +65,7 @@ public class SvangerskapspengerBuilder {
         return this;
     }
 
-    public SvangerskapspengerBuilder medAvtaltFerieListe(List<AvtaltFerie> utenlandsopphold) {
+    public SvangerskapspengerBuilder medAvtaltFerieListe(List<AvtaltFerieDto> avtalteFerieperioder) {
         this.avtalteFerieperioder = avtalteFerieperioder;
         return this;
     }

--- a/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/util/builder/SvangerskapspengerBuilder.java
+++ b/kontrakt/src/test/java/no/nav/foreldrepenger/selvbetjening/kontrakt/innsending/v2/util/builder/SvangerskapspengerBuilder.java
@@ -8,6 +8,7 @@ import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.AnnenInntektD
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.FrilansInformasjonDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.NæringDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.VedleggDto;
+import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.dto.svangerskapspenger.AvtaltFerie;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.BarnDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.UtenlandsoppholdsperiodeDto;
 import no.nav.foreldrepenger.selvbetjening.kontrakt.innsending.v2.dto.svangerskapspenger.SvangerskapspengesøknadDto;
@@ -22,6 +23,7 @@ public class SvangerskapspengerBuilder {
     List<AnnenInntektDto> andreInntekterSiste10Mnd;
     List<UtenlandsoppholdsperiodeDto> utenlandsopphold;
     List<TilretteleggingDto> tilretteleggingsbehov;
+    List<AvtaltFerie> avtalteFerieperioder;
     private List<VedleggDto> vedlegg;
 
     public SvangerskapspengerBuilder(List<TilretteleggingDto> tilretteleggingsbehov) {
@@ -79,6 +81,7 @@ public class SvangerskapspengerBuilder {
             andreInntekterSiste10Mnd,
             utenlandsopphold,
             tilretteleggingsbehov,
+            avtalteFerieperioder,
             vedlegg
         );
     }

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <stonadskonto-regler.version>2.1.1</stonadskonto-regler.version>
-        <selvbetjening-felles.version>3.1.2</selvbetjening-felles.version>
+        <!-- <selvbetjening-felles.version>3.1.2</selvbetjening-felles.version> -->
+        <selvbetjening-felles.version>0.0.1-SNAPSHOT</selvbetjening-felles.version>
 		<token-validation-version>4.0.5</token-validation-version> <!-- Fjerner cookie støtte fra versjon 4.1.0-->
         <boot-conditionals.version>5.1.2</boot-conditionals.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <stonadskonto-regler.version>2.1.1</stonadskonto-regler.version>
-        <!-- <selvbetjening-felles.version>3.1.2</selvbetjening-felles.version> -->
-        <selvbetjening-felles.version>0.0.1-SNAPSHOT</selvbetjening-felles.version>
+        <selvbetjening-felles.version>3.1.5</selvbetjening-felles.version>
 		<token-validation-version>4.0.5</token-validation-version> <!-- Fjerner cookie støtte fra versjon 4.1.0-->
         <boot-conditionals.version>5.1.2</boot-conditionals.version>
 


### PR DESCRIPTION
Etter merging støttes innsending av lister med avtaltferie. Api forventer liste på dette formatet fra frontend (støtter privat arbeidsgiver og virksomhet):
```
"avtaltFerie": [
  {
    "arbeidsforhold": {
      "type": "virksomhet",
      "id": "342352362"
    },
    "fom": "2024-09-18",
    "tom": "2024-09-28"
  }
]
```