### PR TITLE
WIP: securelog ved 422

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/selvbetjening/http/filters/RequestCachingFilter.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/selvbetjening/http/filters/RequestCachingFilter.java
@@ -1,0 +1,32 @@
+package no.nav.foreldrepenger.selvbetjening.http.filters;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+
+import jakarta.servlet.ServletResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+import no.nav.foreldrepenger.selvbetjening.innsending.InnsendingController;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import java.io.IOException;
+
+// filteret cacher body for senere logging ved 422
+@Component
+public class RequestCachingFilter extends GenericFilterBean {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        var httpRequest = (HttpServletRequest) request;
+        if (httpRequest.getRequestURI().contains(InnsendingController.INNSENDING_CONTROLLER_PATH)) {
+            var cachedRequest = new ContentCachingRequestWrapper(httpRequest);
+            chain.doFilter(cachedRequest, response);
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+}

--- a/domene/src/test/java/no/nav/foreldrepenger/selvbetjening/error/CachedRequestLoggingTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/selvbetjening/error/CachedRequestLoggingTest.java
@@ -1,0 +1,77 @@
+package no.nav.foreldrepenger.selvbetjening.error;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import no.nav.boot.conditionals.ConditionalOnNotProd;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import no.nav.foreldrepenger.common.domain.Søker;
+import no.nav.foreldrepenger.selvbetjening.config.JacksonConfiguration;
+import no.nav.foreldrepenger.selvbetjening.http.TokenUtil;
+import no.nav.foreldrepenger.selvbetjening.http.filters.RequestCachingFilter;
+import no.nav.security.token.support.core.api.Unprotected;
+
+
+@Import({ApiExceptionHandler.class})
+@WebMvcTest(controllers = CachedRequestLoggingTest.TestController.class)
+@ContextConfiguration(classes = {
+    JacksonConfiguration.class,
+    CachedRequestLoggingTest.TestController.class,
+    RequestCachingFilter.class})
+@ExtendWith(OutputCaptureExtension.class)
+class CachedRequestLoggingTest {
+    @MockitoBean
+    private TokenUtil tokenUtil;
+    @Autowired
+    private ApiExceptionHandler errorHandler;
+    @Autowired
+    private MockMvc mockMvc;
+
+
+    @Test
+    void ugyldigJsonVedInnsendingTriggerBodyLogging(CapturedOutput output) throws Exception {
+        var ugyldigJson = """
+                {
+                    "søknadsRolle": "helt ukjent verdi",
+                    "målform": "denne også"
+                }
+            """;
+        var forventetLogg = "secureLogger - [/rest/soknad] " + ugyldigJson;
+        mockMvc.perform(post("/rest/soknad")
+                .content(ugyldigJson)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnprocessableEntity());
+        var logs = output.getOut();
+        assertThat(logs).contains(forventetLogg);
+    }
+
+    @RestController
+    @RequestMapping("/rest")
+    @Unprotected
+    @ConditionalOnNotProd
+    static class TestController {
+
+        @PostMapping("/soknad")
+        ResponseEntity<String> testEndpoint(@RequestBody Søker body) {
+            return ResponseEntity.ok("Feiler før vi kommer hit");
+        }
+    }
+}

--- a/domene/src/test/java/no/nav/foreldrepenger/selvbetjening/uttak/UttakControllerTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/selvbetjening/uttak/UttakControllerTest.java
@@ -41,17 +41,20 @@ class UttakControllerTest {
     }
 
     @Test
-    void mor_og_far_rett_to_tette() {
+    void mor_og_far_rett_to_tette_første_før_juli2024() {
         var controller = new UttakController(uttakCore2024);
+        var fødselsdato = LocalDate.of(2024,6, 15);
+        var termindato = fødselsdato.minusWeeks(1);
+        var nesteFamiliehendelseDato = fødselsdato.plusMonths(11);
         var grunnlag = new KontoBeregningGrunnlagDto(
             Rettighetstype.BEGGE_RETT,
             Brukerrolle.MOR,
             1,
-            LocalDate.now().minusMonths(7),
-            LocalDate.now().minusMonths(7).minusWeeks(1),
+            fødselsdato,
+            termindato,
             null,
             false,
-            LocalDate.now()
+            nesteFamiliehendelseDato
         );
         var resultat = controller.beregn(grunnlag);
 


### PR DESCRIPTION
Inneholder to ting: 

1. fix på en test som nå er ødelagt (kan cherrypicke til egen branch om ok).
2. utkast til mekanisme for å logge request body til secure logs ved 422. Disse feilene skjer som regel når søknaden feiler ved deserialisering (og dermed er det ikke noen dto-objekter som kan logges med den vanlige mekanismen for å logge innsending til securelogs).

Merk følgende som gjør at punkt 2 ikke er klar for merging: dersom man skal logge disse må man ha inn mekanisme for å sanitize mtp log injection.

Se bakgrunn for punkt 2: https://nav-it.slack.com/archives/CEKQHNLLU/p1738700801392939